### PR TITLE
Merge changes from kh4 branch into main

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.7
   - pyproj
-  - scikit-image>=0.18
+  - scikit-image>=0.19
   - geopandas
   - matplotlib
   - sphinx

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='spymicmac',
               'register_ortho = spymicmac.tools.register_ortho:main',
               'remove_crosses = spymicmac.tools.remove_crosses:main',
               'remove_measures = spymicmac.tools.remove_measures:main',
+              'resample_hexagon = spymicmac.tools.resample_hexagon:main',
               'write_micmac_xml = spymicmac.tools.write_micmac_xml:main'
           ],
       },

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -984,10 +984,10 @@ def get_rough_frame(img):
     img_lowres = downsample_image(img, fact=10)
 
     rowmean = img_lowres.mean(axis=0)
-    # smooth_row = _moving_average(rowmean, n=10)
+    smooth_row = _moving_average(rowmean, n=5)
 
     colmean = img_lowres.mean(axis=1)
-    # smooth_col = _moving_average(colmean, n=10)
+    smooth_col = _moving_average(colmean, n=5)
 
     # xmin = 10 * np.where(rowmean > np.percentile(rowmean, 10))[0][0]
     # xmin = 10 * (np.argmax(np.diff(smooth_row)) + 1)
@@ -1006,11 +1006,11 @@ def get_rough_frame(img):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
-    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
 
-    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
-    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
 
     left_ind = max(row_peaks[np.where(row_peaks < 0.2 * rowmean.size)[0]])
     right_ind = min(row_troughs[np.where(row_troughs > 0.8 * rowmean.size)[0]])

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -795,6 +795,14 @@ def ocm_show_wagon_wheels(img, size, width=3, img_border=None):
 
 
 def find_crosses(img, cross):
+    """
+    Find all cross markers in an image.
+
+    :param array-like img: the image
+    :param array-like cross: the cross template to use
+    :returns:
+        - **grid_df** (*pandas.DataFrame*) -- a dataframe of marker locations and offsets
+    """
 
     sub_coords = []
     simgs, top_inds, left_inds = splitter(img, (4, 8), overlap=4*cross.shape[0])
@@ -831,6 +839,15 @@ def find_crosses(img, cross):
 
 
 def match_reseau_grid(img, coords, cross):
+    """
+    Find the best match for each KH-9 mapping camera reseau grid point, given a list of potential matches.
+
+    :param array-like img: the image to use
+    :param array-like coords: the coordinates of the potential matches
+    :param array-like cross: the cross template to use.
+    :returns:
+        - **grid_df** (*pandas.DataFrame*) -- a DataFrame of grid locations and match points
+    """
     matchpoints = MultiPoint(coords[:, ::-1])
     # top, bot, left, right = find_grid_border(coords)
     left, right, top, bot = get_rough_frame(img)
@@ -969,6 +986,14 @@ def find_reseau_border(img, rough_ext, cross, tsize=300):
 
 
 def downsample_image(img, fact=4):
+    """
+    Rescale an image using Lanczos resampling
+
+    :param array-like img: the image to rescale
+    :param numeric fact: the number by which to divide the image width and height (default: 4)
+    :return:
+        - **rescaled** (*array-like*) -- the rescaled image
+    """
     _img = PIL.Image.fromarray(img)
     return np.array(_img.resize((np.array(_img.size) / fact).astype(int), PIL.Image.Resampling.LANCZOS))
 
@@ -1115,8 +1140,8 @@ def find_reseau_grid(fn_img, csize=361, return_val=False):
     print('Mean y residual: {:.2f} pixels'.format(grid_df.di.abs().mean()))
     print('Mean residual: {:.2f} pixels'.format(grid_df.resid.mean()))
 
-    ax.quiver(grid_df.search_j, grid_df.search_i, grid_df.dj, grid_df.di, color='r')
-    ax.plot(grid_df.search_j[~inliers], grid_df.search_i[~inliers], 'b+')
+    ax.quiver(grid_df.match_j, grid_df.match_i, grid_df.dj, grid_df.di, color='r')
+    ax.plot(grid_df.match_j[~inliers], grid_df.match_i[~inliers], 'b+')
 
     this_out = os.path.splitext(fn_img)[0]
     fig.savefig(os.path.join('match_imgs', this_out + '_matches.png'), bbox_inches='tight', dpi=200)
@@ -1194,6 +1219,13 @@ def remove_crosses(fn_img):
 
 
 def get_parts_list(im_pattern):
+    """
+    Find all of the parts of a scanned image that match a given filename pattern
+
+    :param str im_pattern: the image pattern to match
+    :returns:
+        - **parts_list** (*list*) -- a list of all parts of the image that match the pattern.
+    """
     imlist = glob(im_pattern + '*.tif')
     imlist.sort()
 

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1006,11 +1006,11 @@ def get_rough_frame(img):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_abs=10).flatten()
-    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_abs=10).flatten()
+    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
 
-    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_abs=10).flatten()
-    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_abs=10).flatten()
+    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
+    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_rel=0.1, num_peaks=2).flatten()
 
     left_ind = max(row_peaks[np.where(row_peaks < 0.2 * rowmean.size)[0]])
     right_ind = min(row_troughs[np.where(row_troughs > 0.8 * rowmean.size)[0]])

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1084,7 +1084,7 @@ def get_parts_list(im_pattern):
     return [os.path.splitext(fn_img.split('_')[-1])[0] for fn_img in imlist]
 
 
-def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, reversed=False):
+def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, is_reversed=False):
     """
     Join multiple parts of a scanned image.
 
@@ -1092,11 +1092,11 @@ def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, reversed
     :param int overlap: the overlap, in pixels, between the image parts.
     :param int block_size: the number of rows each sub-block should cover. Defaults to overlap.
     :param bool blend: apply a linear blend between the two scanned halves (default: True).
-    :param bool reversed: parts are in reversed order (i.e., part b is the left part, part a is the right part)
+    :param bool is_reversed: parts are in reversed order (i.e., part b is the left part, part a is the right part)
     """
     parts = get_parts_list(im_pattern)
 
-    if reversed:
+    if is_reversed:
         parts.reverse()
 
     left = io.imread('{}_{}.tif'.format(im_pattern, parts[0]))
@@ -1104,6 +1104,8 @@ def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, reversed
         right = io.imread('{}_{}.tif'.format(im_pattern, part))
 
         left = join_halves(left, right, overlap, block_size=block_size, blend=blend)
+        if len(parts) > 2:
+            io.imsave('tmp_left.tif', left.astype(np.uint8))
 
     io.imsave('{}.tif'.format(im_pattern), left.astype(np.uint8))
 

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1111,6 +1111,10 @@ def find_reseau_grid(fn_img, csize=361, return_val=False):
     print('Grid points found.')
     os.makedirs('match_imgs', exist_ok=True)
 
+    print('Mean x residual: {:.2f} pixels'.format(grid_df.dj.abs().mean()))
+    print('Mean y residual: {:.2f} pixels'.format(grid_df.di.abs().mean()))
+    print('Mean residual: {:.2f} pixels'.format(grid_df.resid.mean()))
+
     ax.quiver(grid_df.search_j, grid_df.search_i, grid_df.dj, grid_df.di, color='r')
     ax.plot(grid_df.search_j[~inliers], grid_df.search_i[~inliers], 'b+')
 

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1266,13 +1266,14 @@ def match_halves(left, right, overlap, block_size=None):
     return model
 
 
-def resample_hex(fn_img, scale, ori='InterneScan'):
+def resample_hex(fn_img, scale, ori='InterneScan', warp_order=3):
     """
     Uses a piecewise affine transformation to resample a KH-9 Mapping Camera image based on the reseau grid.
 
     :param str fn_img: the filename of the image to resample
     :param int scale: the number of pixels per mm of the scanned image
     :param str ori: the Ori directory that contains both MeasuresCamera.xml and MeasuresIm (default: InterneScan)
+    :param int warp_order: the order of resampling to pass to skimage.transform.warp (default: 3, cubic)
     """
 
     img = io.imread(fn_img)
@@ -1286,6 +1287,6 @@ def resample_hex(fn_img, scale, ori='InterneScan'):
     tform = PiecewiseAffineTransform()
     tform.estimate(src, dst)
 
-    out = warp(img, tform, output_shape=(src[:, 1].max(), src[:, 0].max()), preserve_range=True, order=3)
+    out = warp(img, tform, output_shape=(src[:, 1].max(), src[:, 0].max()), preserve_range=True, order=warp_order)
 
     io.imsave('OIS-Reech_{}'.format(fn_img), out.astype(np.uint8))

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1006,11 +1006,11 @@ def get_rough_frame(img):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_rel=0.2).flatten()
-    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_rel=0.2).flatten()
+    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_abs=10).flatten()
+    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_abs=10).flatten()
 
-    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_rel=0.2).flatten()
-    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_rel=0.2).flatten()
+    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_abs=10).flatten()
+    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_abs=10).flatten()
 
     left_ind = max(row_peaks[np.where(row_peaks < 0.2 * rowmean.size)[0]])
     right_ind = min(row_troughs[np.where(row_troughs > 0.8 * rowmean.size)[0]])

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -984,10 +984,10 @@ def get_rough_frame(img):
     img_lowres = downsample_image(img, fact=10)
 
     rowmean = img_lowres.mean(axis=0)
-    smooth_row = _moving_average(rowmean)
+    # smooth_row = _moving_average(rowmean, n=10)
 
     colmean = img_lowres.mean(axis=1)
-    smooth_col = _moving_average(colmean)
+    # smooth_col = _moving_average(colmean, n=10)
 
     # xmin = 10 * np.where(rowmean > np.percentile(rowmean, 10))[0][0]
     # xmin = 10 * (np.argmax(np.diff(smooth_row)) + 1)
@@ -1000,27 +1000,42 @@ def get_rough_frame(img):
 
     # if xmax / img.shape[1] > 0.999:
     #     xmax = np.nan
-    sorted_row = np.argsort(np.diff(smooth_row))
+    # sorted_row = np.argsort(np.diff(smooth_row))
 
     # get the location in the sorted array that corresponds to the minimum and maximum
     # of the difference, that's also in the right half of the image
-    min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
-    max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
+    # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
+    # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
+    col_peaks = peak_local_max(np.diff(colmean), min_distance=20, threshold_rel=0.2).flatten()
+    col_troughs = peak_local_max(-np.diff(colmean), min_distance=20, threshold_rel=0.2).flatten()
 
-    xmin = 10 * (sorted_row[min_ind] + 1)
-    xmax = 10 * (sorted_row[max_ind] + 1)
+    row_peaks = peak_local_max(np.diff(rowmean), min_distance=20, threshold_rel=0.2).flatten()
+    row_troughs = peak_local_max(-np.diff(rowmean), min_distance=20, threshold_rel=0.2).flatten()
+
+    left_ind = max(row_peaks[np.where(row_peaks < 0.2 * rowmean.size)[0]])
+    right_ind = min(row_troughs[np.where(row_troughs > 0.8 * rowmean.size)[0]])
+
+    top_ind = max(col_peaks[np.where(col_peaks < 0.2 * colmean.size)[0]])
+    bot_ind = min(col_troughs[np.where(col_troughs > 0.8 * colmean.size)[0]])
+
+    # xmin = 10 * (sorted_row[min_ind] + 1)
+    # xmax = 10 * (sorted_row[max_ind] + 1)
+    xmin = 10 * (left_ind + 1)
+    xmax = 10 * (right_ind + 1)
 
     # ymin = 10 * np.where(colmean > np.percentile(colmean, 10))[0][0]
     # ymax = 10 * np.where(colmean > np.percentile(colmean, 10))[0][-1]
-    sorted_col = np.argsort(np.diff(smooth_col))
+    # sorted_col = np.argsort(np.diff(smooth_col))
 
     # get the location in the sorted array that corresponds to the minimum and maximum
     # of the difference, that's also in the right half of the image
-    min_ind = np.where(sorted_col < 0.2 * sorted_col.size)[0][-1]
-    max_ind = np.where(sorted_col > 0.8 * sorted_col.size)[0][0]
+    # min_ind = np.where(sorted_col < 0.2 * sorted_col.size)[0][-1]
+    # max_ind = np.where(sorted_col > 0.8 * sorted_col.size)[0][0]
+    ymin = 10 * (top_ind + 1)
+    ymax = 10 * (bot_ind + 1)
 
-    ymin = 10 * (sorted_col[min_ind] + 1)
-    ymax = 10 * (sorted_col[max_ind] + 1)
+    # ymin = 10 * (sorted_col[min_ind] + 1)
+    # ymax = 10 * (sorted_col[max_ind] + 1)
 
     return xmin, xmax, ymin, ymax
 

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -750,14 +750,17 @@ def find_cross(img, pt, cross, tsize=300):
         return np.nan, np.nan
 
 
-def find_wagon_wheels(img, size, width=3, img_border=None):
+# all credit to joe kennedy for the name of this function.
+def ocm_show_wagon_wheels(img, size, width=3, img_border=None):
     """
+    Find all "wagon wheel" markers in an image.
 
-    :param img:
-    :param size:
-    :param width:
-    :param img_border:
-    :return:
+    :param array-like img: the image
+    :param int size: the size of the marker (in pixels)
+    :param int width: the width/thickness of the cross, in pixels (default: 3)
+    :param img_border: the approximate top and bottom rows of the image frame. If not set,
+        calls get_rough_frame() on the image.
+    :returns: **coords** an Nx2 array of the location of the detected markers.
     """
     if img_border is None:
         _, _, top, bot = get_rough_frame(img)

--- a/spymicmac/image.py
+++ b/spymicmac/image.py
@@ -1288,12 +1288,12 @@ def resample_hex(fn_img, scale, ori='InterneScan'):
     ds.FlushCache()
     ds = None
 
-    out_ds = gdal.Warp('tmp.tif', fn_img, xRes=1, yRes=1,
+    out_ds = gdal.Warp('tmp_{}.tif'.format(fn_img), fn_img, xRes=1, yRes=1,
                        outputBounds=[0, 0, all_meas.j_cam.max(), all_meas.i_cam.max()],
                        resampleAlg=gdal.GRA_Lanczos)
     out_ds = None
 
-    img = io.imread('tmp.tif')
+    img = io.imread('tmp_{}.tif'.format(fn_img))
     io.imsave('OIS-Reech_{}'.format(fn_img), np.flipud(img).astype(np.uint8))
 
-    os.remove('tmp.tif')
+    os.remove('tmp_{}.tif'.format(fn_img))

--- a/spymicmac/micmac.py
+++ b/spymicmac/micmac.py
@@ -315,13 +315,22 @@ def create_localchantier_xml(name='KH9MC', short_name='KH-9 Hexagon Mapping Came
     tree.write('MicMac-LocalChantierDescripteur.xml', pretty_print=True, xml_declaration=True, encoding="utf-8")
 
 
-def init_autocal(imsize=(32857, 15714)):
+# TODO: make this more general by changing the name of the file based on foc, camera name
+def init_autocal(imsize=(32200, 15400), framesize=(460, 220), foc=304.8, camname='KH9MC'):
     """
-    Create an AutoCal xml file for the KH-9 Mapping Camera for use in the Tapas step.
+    Create an AutoCal xml file for use in the Tapas step. Default values are for KH-9 Hexagon Mapping Camera.
 
-    :param array-like imsize: the size of the image (width, height) in pixels
+    When calling mm3d Tapas, be sure to use "InCal=Init":
+
+        mm3d Tapas RadialBasic "OIS.*tif" InCal=Init Out=Relative LibFoc=0
+
+    :param array-like imsize: the size of the image (width, height) in pixels (default: (32200, 15400))
+    :param array-like framesize: the size of the image (width, height) in mm (default: (460, 220))
+    :param float foc: nominal focal length, in mm (default: 304.8)
     """
     os.makedirs('Ori-Init', exist_ok=True)
+
+    scale = np.mean([imsize[0] / framesize[0], imsize[1] / framesize[1]])
 
     pp = np.array(imsize) / 2
 
@@ -330,7 +339,7 @@ def init_autocal(imsize=(32857, 15714)):
         E.CalibrationInternConique(
             E.KnownConv('eConvApero_DistM2C'),
                 E.PP('{} {}'.format(pp[0], pp[1])),
-                E.F('21771.2778464694711'),
+                E.F('{}'.format(scale * foc)),
                 E.SzIm('{} {}'.format(imsize[0], imsize[1])),
                 E.CalibDistortion(
                     E.ModRad(
@@ -344,8 +353,13 @@ def init_autocal(imsize=(32857, 15714)):
     )
 
     tree = etree.ElementTree(outxml)
-    tree.write(os.path.join('Ori-Init', 'AutoCal_Foc-304800_KH9MC.xml'),
+    tree.write(os.path.join('Ori-Init', 'AutoCal_Foc-{}_{}.xml'.format(int(foc*1000), camname)),
                pretty_print=True, xml_declaration=True, encoding="utf-8")
+
+
+def parse_localchantier(fn_chant):
+    pass
+
 
 
 def get_match_pattern(imlist):

--- a/spymicmac/tools/find_reseau_grid.py
+++ b/spymicmac/tools/find_reseau_grid.py
@@ -9,11 +9,6 @@ def _argparser():
                                       formatter_class=argparse.RawDescriptionHelpFormatter)
     _parser.add_argument('fn_img', action='store', type=str, help='Image to find Reseau grid in.')
     _parser.add_argument('-csize', action='store', type=int, default=361, help='Reseau mark template size [361 pixels]')
-    _parser.add_argument('-tsize', action='store', type=int, default=300, help='half-size of search window [300 pixels]')
-    _parser.add_argument('-nproc', action='store', type=int, default=1,
-                         help='Number of processors to use [1].')
-    _parser.add_argument('-j', '--joined', action='store_true',
-                         help='Image is a joined KH-9 scan, rather than half of a scanned image.')
     return _parser
 
 
@@ -22,11 +17,7 @@ def main():
     parser = _argparser()
     args = parser.parse_args()
 
-    find_reseau_grid(args.fn_img,
-                     csize=args.csize,
-                     tsize=args.tsize,
-                     nproc=args.nproc,
-                     joined=args.joined)
+    find_reseau_grid(args.fn_img, csize=args.csize)
 
 
 if __name__ == "__main__":

--- a/spymicmac/tools/find_reseau_grid.py
+++ b/spymicmac/tools/find_reseau_grid.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python
 import argparse
+import multiprocessing as mp
 import numpy as np
 from spymicmac.image import find_reseau_grid
+
+
+def batch_wrapper(argsin):
+    find_reseau_grid(**argsin)
 
 
 def _argparser():
     _parser = argparse.ArgumentParser(description="Find Reseau marks in a scanned KH-9 Hexagon image.",
                                       formatter_class=argparse.RawDescriptionHelpFormatter)
-    _parser.add_argument('fn_img', action='store', type=str, help='Image to find Reseau grid in.')
+    _parser.add_argument('img', action='store', type=str, nargs='+', help='Image(s) to find Reseau marks in.')
     _parser.add_argument('-csize', action='store', type=int, default=361, help='Reseau mark template size [361 pixels]')
+    _parser.add_argument('-n', '--nproc', type=int, default=1, help='number of sub-processes to use [Default: 1].')
     return _parser
 
 
@@ -17,7 +23,22 @@ def main():
     parser = _argparser()
     args = parser.parse_args()
 
-    find_reseau_grid(args.fn_img, csize=args.csize)
+    if args.nproc > 1 and len(args.img) > 1:
+        pool = mp.Pool(args.nproc, maxtasksperchild=1)
+
+        arg_dict = {'csize': args.csize}
+        pool_args = [{'fn_img': fn_img} for fn_img in args.img]
+
+        for d in pool_args:
+            d.update(arg_dict)
+
+        pool.map(batch_wrapper, pool_args, chunksize=1)
+        pool.close()
+        pool.join()
+    else:
+        for fn_img in args.img:
+            find_reseau_grid(fn_img, csize=args.csize)
+
 
 
 if __name__ == "__main__":

--- a/spymicmac/tools/join_hexagon.py
+++ b/spymicmac/tools/join_hexagon.py
@@ -31,7 +31,7 @@ def main():
                      overlap=args.overlap,
                      block_size=args.block_size,
                      blend=args.blend,
-                     reversed=args.reversed)
+                     is_reversed=args.reversed)
 
 
 if __name__ == "__main__":

--- a/spymicmac/tools/join_hexagon.py
+++ b/spymicmac/tools/join_hexagon.py
@@ -15,7 +15,7 @@ def _argparser():
                         help='the number of rows each sub-block should cover. Defaults to overlap value.')
     parser.add_argument('-b', '--blend', action='store_true',
                         help='Blend across image halves to prevent a sharp line at edge.')
-    parser.add_argument('-r', '--reverse', action='store_true',
+    parser.add_argument('-r', '--reversed', action='store_true',
                         help='parts are in reversed order (i.e., part b is the left part, part a is the right part)')
     return parser
 

--- a/spymicmac/tools/join_hexagon.py
+++ b/spymicmac/tools/join_hexagon.py
@@ -5,18 +5,18 @@ from spymicmac.image import join_hexagon
 
 
 def _argparser():
-    parser = argparse.ArgumentParser(description="Join two halves of a scanned KH-9 Hexagon image (or four parts of a scanned KH-4 Corona image).",
+    parser = argparse.ArgumentParser(description="Join parts of a scanned image",
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-o', '--overlap', action='store', type=int, default=2000,
-                        help='overlap search width between two images [2000]')
     parser.add_argument('-p', '--pattern', action='store', type=str, default='DZB',
                        help='Match pattern for images [DZB]')
+    parser.add_argument('-o', '--overlap', action='store', type=int, default=2000,
+                        help='overlap search width between two images [2000]')
+    parser.add_argument('-k', '--block_size', action='store', type=int, default=None,
+                        help='the number of rows each sub-block should cover. Defaults to overlap value.')
     parser.add_argument('-b', '--blend', action='store_true',
                         help='Blend across image halves to prevent a sharp line at edge.')
-    parser.add_argument('-c', '--corona', action='store_true',
-                        help='Images are Corona KH-4/KH-4A scans (i.e., there are 4 parts).')
-    parser.add_argument('-m', '--main', action='store_true',
-                        help='Images are from KH-9 main camera (i.e., there are 8 parts).')
+    parser.add_argument('-r', '--reverse', action='store_true',
+                        help='parts are in reversed order (i.e., part b is the left part, part a is the right part)')
     return parser
 
 
@@ -29,9 +29,9 @@ def main():
         print(im)
         join_hexagon(im,
                      overlap=args.overlap,
+                     block_size=args.block_size,
                      blend=args.blend,
-                     corona=args.corona,
-                     main=args.main)
+                     reversed=args.reversed)
 
 
 if __name__ == "__main__":

--- a/spymicmac/tools/resample_hexagon.py
+++ b/spymicmac/tools/resample_hexagon.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import argparse
+import multiprocessing as mp
+from spymicmac.image import resample_hex
+
+
+def batch_wrapper(argsin):
+    resample_hex(**argsin)
+
+
+def _argparser():
+    parser = argparse.ArgumentParser(description="Use a piecewise affine transformation to resample KH-9 images"
+                                                 " using the reseau grid",
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('img', action='store', type=str, nargs='+', help='Image(s) to resample from.')
+    parser.add_argument('-s', '--scale', action='store', type=int, default=70,
+                        help='The scale of the resampled image, in pixels per mm. [Default: 70]')
+    parser.add_argument('-o', '--ori', action='store', type=str, default='InterneScan',
+                        help='The Ori directory that contains both MeasuresCamera.xml and MeasuresIm for each image. '
+                             '[Default: InterneScan]')
+    parser.add_argument('-n', '--nproc', type=int, default=1, help='number of sub-processes to use [Default: 1].')
+    return parser
+
+
+def main():
+    parser = _argparser()
+    args = parser.parse_args()
+
+    if args.nproc > 1 and len(list(args.img)) > 1:
+        pool = mp.Pool(args.nproc, maxtasksperchild=1)
+
+        arg_dict = {'scale': args.scale, 'ori': args.ori}
+        pool_args = [{'fn_img': fn_img} for fn_img in args.img]
+
+        for d in pool_args:
+            d.update(arg_dict)
+
+        pool.map(batch_wrapper, pool_args, chunksize=1)
+        pool.close()
+        pool.join()
+    else:
+        for fn_img in list(args.img):
+            print(fn_img)
+            resample_hex(fn_img, scale=args.scale, ori=args.ori)
+
+
+if __name__ == "__main__":
+    main()

--- a/spymicmac/tools/resample_hexagon.py
+++ b/spymicmac/tools/resample_hexagon.py
@@ -5,6 +5,7 @@ from spymicmac.image import resample_hex
 
 
 def batch_wrapper(argsin):
+    print(argsin['fn_img'])
     resample_hex(**argsin)
 
 
@@ -26,7 +27,7 @@ def main():
     parser = _argparser()
     args = parser.parse_args()
 
-    if args.nproc > 1 and len(list(args.img)) > 1:
+    if args.nproc > 1 and len(args.img) > 1:
         pool = mp.Pool(args.nproc, maxtasksperchild=1)
 
         arg_dict = {'scale': args.scale, 'ori': args.ori}
@@ -39,7 +40,7 @@ def main():
         pool.close()
         pool.join()
     else:
-        for fn_img in list(args.img):
+        for fn_img in args.img:
             print(fn_img)
             resample_hex(fn_img, scale=args.scale, ori=args.ori)
 


### PR DESCRIPTION
This PR would update the `main` branch with the following changes from the `kh4` branch:

- change dependency to scikit-image >= 0.19
- add resample_hexagon command line tool, which replaces using mm3d ReSampFid for resampling KH-9 MC images


`image` module:
- add functions to find, match "wagon wheel" fiducial marks (`ocm_show_wagon_wheels`)
- re-factor, improve reseau field matching using new `find_crosses` and `match_reseau_grid` functions
- change `join_hexagon` to be able to handle KH-9 PC images
- add `resample_hex`, which uses `gdal.Warp` to resample KH-9 MC images based on the reseau grid


`micmac` module:
- update `init_autocal` to be able to specify camera name, focal length, frame size


`tools` module:
- `find_reseau_grid` now uses multiprocessing to run on multiple images, rather than on a single image
- `join_hexagon` changes to match `image.join_hexagon`
- `resample_hexagon` is now included as a command line tool