### PR TITLE
fix warnings, add features

### DIFF
--- a/spymicmac/tools/preprocess_kh9.py
+++ b/spymicmac/tools/preprocess_kh9.py
@@ -107,20 +107,18 @@ def main():
     # now, do all the steps we were asked to do, in order
     if do['extract']:
         imlist = extract(args.tar_ext)
-        imlist = [os.path.splitext(tfile)[0] for tfile in imlist]
+        imlist = [tfile.split(args.tar_ext)[0] for tfile in imlist]
     else:
         imlist = list(set([os.path.splitext(fn)[0].split('_')[0] for fn in glob('DZB*.tif')]))
         imlist.sort()
 
     if do['join']:
         print('Joining scanned image halves.')
-        for fn_img in imlist:
-            print(fn_img)
-            join_hexagon(fn_img, blend=args.blend)
-
         os.makedirs('halves', exist_ok=True)
 
         for fn_img in imlist:
+            print(fn_img)
+            join_hexagon(fn_img, blend=args.blend)
             shutil.move(fn_img + '_a.tif', 'halves')
             shutil.move(fn_img + '_b.tif', 'halves')
 

--- a/spymicmac/usgs.py
+++ b/spymicmac/usgs.py
@@ -103,3 +103,31 @@ def get_usgs_footprints(imlist, dataset='DECLASSII'):
         gdf.set_crs(epsg=4326, inplace=True)
 
         return gdf
+
+
+def landsat_to_gdf(results):
+    """
+    Convert USGS Landsat search results to a GeoDataFrame
+
+    :param list results: a list of results (i.e., the 'data' value returned by api.scene_metadata)
+    :return:
+        - **meta_gdf** (*geopandas.GeoDataFrame*) - a GeoDataFrame of search results
+    """
+    meta_gdf = gpd.GeoDataFrame()
+
+    for ind, res in enumerate(results):
+        keys = [f['fieldName'] for f in res['metadata']]
+        values = [f['value'] for f in res['metadata']]
+        metadata = dict(zip(keys, values))
+
+        meta_gdf.loc[ind, 'ID'] = metadata['Landsat Product Identifier L1']
+        meta_gdf.loc[ind, 'geometry'] = Polygon(res['spatialCoverage']['coordinates'][0])
+        meta_gdf.loc[ind, 'acq_date'] = metadata['Date Acquired']
+        meta_gdf.loc[ind, 'land_cc'] = float(metadata['Land Cloud Cover'])
+        meta_gdf.loc[ind, 'scene_cc'] = float(metadata['Scene Cloud Cover L1'])
+        meta_gdf.loc[ind, 'day_night'] = metadata['Day/Night Indicator']
+        # meta_gdf.loc[ind, 'rmse_x'] = float(metadata['Geometric RMSE Model X'])
+        # meta_gdf.loc[ind, 'rmse_y'] = float(metadata['Geometric RMSE Model Y'])
+
+    return meta_gdf.set_crs(epsg=4326)
+


### PR DESCRIPTION
This incorporates the following changes:

- fix userwarnings raised by `shapely` and `scikit-image`
- makes the outlier filting in `micmac.iterate_campari` more restrictive
- fixes image list generation in `preprocess_kh9`
- adds `usgs.landsat_to_gdf` to export results of USGS Landsat search to GeoDataFrame