### PR TITLE
it probably helps to check script/function names first.

### DIFF
--- a/doc/spymicmac/scripts/create_local_chantier.rst
+++ b/doc/spymicmac/scripts/create_local_chantier.rst
@@ -1,7 +1,0 @@
-create_local_chantier
-=================================
-
-.. argparse::
-   :filename: ../spymicmac/tools/create_local_chantier.py
-   :func: _argparser
-   :prog: create_local_chantier

--- a/doc/spymicmac/scripts/create_localchantier_xml.rst
+++ b/doc/spymicmac/scripts/create_localchantier_xml.rst
@@ -1,0 +1,7 @@
+create_localchantier_xml
+=================================
+
+.. argparse::
+   :filename: ../spymicmac/tools/create_localchantier_xml.py
+   :func: _argparser
+   :prog: create_localchantier_xml


### PR DESCRIPTION
Fixes error in building documentation related to an incorrect filename.