### PR TITLE
updates to register, pre-processing, micmac

### DIFF
--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -925,9 +925,9 @@ def campari(in_gcps, outdir, img_pattern, sub, dx, ortho_res, allfree=True,
                           inori + sub,
                           outori + sub,
                           'GCP=[{},{},{},{}]'.format(os.path.join(outdir, fn_gcp),
-                                                     np.abs(dx) / 2,  # should be correct within 1/2 pixel
+                                                     np.abs(dx) / 4,  # should be correct within 1/4 pixel
                                                      os.path.join(outdir, fn_meas),
-                                                     0.25),  # should be correct within 1/4 pixel
+                                                     1),  # best balance for distortion
                           'SH={}'.format(homol),
                           'AllFree={}'.format(int(allfree))], stdin=echo.stdout)
     p.wait()

--- a/src/spymicmac/tools/preprocess_kh9.py
+++ b/src/spymicmac/tools/preprocess_kh9.py
@@ -72,6 +72,8 @@ def _argparser():
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--steps', action='store', type=str, nargs='+', default='all',
                         help='The pre-processing steps to run.')
+    parser.add_argument('--skip', action='store', type=str, nargs='+', default='none',
+                        help='The pre-processing steps to skip.')
     parser.add_argument('--tar_ext', action='store', type=str, default='.tgz',
                         help='Extension for tar files (default: .tgz)')
     parser.add_argument('-s', '--scale', action='store', type=int, default=70,
@@ -117,6 +119,11 @@ def main():
     else:
         do_step = [step in args.steps for step in proc_steps]
     do = dict(zip(proc_steps, do_step))
+
+    if args.skip != 'none':
+        for step in args.skip:
+            if step in do.keys():
+                do.update({step: False})
 
     # create the necessary xml files, but only if they don't exist
     if not os.path.exists(os.path.join('Ori-Init', 'AutoCal_Foc-304800_KH9MC.xml')):


### PR DESCRIPTION
This PR merges the following updates:

`spymicmac.micmac`:
- `get_campari_residuals` now returns the full x,y,z distance residuals as 'camp_dist'; the xy distance is 'camp_xy'
- minor changes to `campari` to balance distortion and minimizing residuals
- add an interface for calling `mm3d PostProc Banana`
- add option for a mask when calling `dem_to_text`

`spymicmac.tools.preprocess_kh9`:
- add contrast-limited adaptive histogram equalization as a step

