### PR TITLE
improved hpc performance

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,8 @@ dependencies:
   - pyasn1
   - numba
   - earthengine-api
+  - imagemagick
+  - exiftool
   - pillow>9.1.0
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
       'sphinx',
       'sphinx-argparse',
       'sphinx-rtd-theme',
-      'earthengine-api'
+      'earthengine-api',
+      'imagemagick',
+      'exiftool'
 ]
 dynamic = ["version"]
 

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -368,7 +368,8 @@ def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, is_rever
 
     io.imsave('{}.tif'.format(im_pattern), left.astype(np.uint8))
 
-    os.remove('tmp_left.tif') # clean up after we're done
+    if len(parts) > 2:
+        os.remove('tmp_left.tif') # clean up after we're done
 
 
 def _blend(_left, _right, left_shape):

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -274,10 +274,10 @@ def get_rough_frame(img, fact=10):
     img_lowres = resample.downsample(img, fact=fact)
 
     rowmean = _spike_filter(img_lowres, axis=0)
-    smooth_row = _moving_average(rowmean, n=5)
+    smooth_row = _moving_average(rowmean, n=10)
 
     colmean = _spike_filter(img_lowres, axis=1)
-    smooth_col = _moving_average(colmean, n=5)
+    smooth_col = _moving_average(colmean, n=10)
 
     # xmin = 10 * np.where(rowmean > np.percentile(rowmean, 10))[0][0]
     # xmin = 10 * (np.argmax(np.diff(smooth_row)) + 1)

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -368,6 +368,8 @@ def join_hexagon(im_pattern, overlap=2000, block_size=None, blend=True, is_rever
 
     io.imsave('{}.tif'.format(im_pattern), left.astype(np.uint8))
 
+    os.remove('tmp_left.tif') # clean up after we're done
+
 
 def _blend(_left, _right, left_shape):
     first = np.where(np.sum(_right, axis=0) > 0)[0][0]

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -952,7 +952,8 @@ def find_rail_marks(img, marker):
 
     res = cv2.matchTemplate(img_lowres.astype(np.uint8), marker.astype(np.uint8), cv2.TM_CCORR_NORMED)
 
-    coords = peak_local_max(res, threshold_rel=0.5, min_distance=10).astype(np.float64)
+    coords = peak_local_max(res, threshold_rel=np.percentile(res, 99.9) / res.max(),
+                            min_distance=10).astype(np.float64)
     coords += marker.shape[0] / 2 - 0.5
     coords *= 10
 

--- a/src/spymicmac/preprocessing.py
+++ b/src/spymicmac/preprocessing.py
@@ -36,7 +36,7 @@ def extract(tar_ext='.tgz'):
     else:
         print('No tar files found, skipping.')
         # we still want to make sure that we have a list of images to work with.
-        tarlist = list(set([os.path.splitext(fn)[0].split('_')[0] for fn in glob('DZB*.tif')]))
+        tarlist = list(set([os.path.splitext(fn)[0].split('_')[0] for fn in glob('D*.tif')]))
         tarlist.sort()
 
     return tarlist

--- a/src/spymicmac/tools/preprocess_kh9.py
+++ b/src/spymicmac/tools/preprocess_kh9.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import shutil
 import tarfile
+import multiprocessing as mp
 import numpy as np
 from glob import glob
 from skimage import io, filters, exposure
@@ -219,12 +220,12 @@ def main():
     if do['resample']:
         os.makedirs('Orig', exist_ok=True)
         # now, resample the images
-        if args.nproc > 1 and len(args.img) > 1:
+        if args.nproc > 1 and len(imlist) > 1:
             batch_resample(imlist, args)
         else:
             for fn_img in imlist:
                 print(f'Resampling {fn_img}')
-                resample_hex(fn_im + '.tif', scale=args.scale)
+                resample_hex(fn_img + '.tif', scale=args.scale)
 
         for fn_img in imlist:
             shutil.move(fn_img + '.tif', 'Orig')


### PR DESCRIPTION
This PR will incorporate the following changes, intended to help improve performance on HPC clusters and fix some other minor issues:

`environment.yml` and `pyproject.toml`:
- add **imagemagick** and **exiftools** as a requirement, as these are needed by micmac (and not always installable by the user)

`spymicmac.image`:
- increase smoothing in `get_rough_frame`
- remove temporary files after `join_hexagon` finishes

`spymicmac.matching`:
- add **marker** as an argument to `find_rail_marks`; future work will include guessing the correct template based on the mission

`spymicmac.preprocessing`:
 - search for all declassified image file types (**DS**, **DZB**, **D3C**), not just KH-9 Mapping Camera (**DZB**).

`spymicmac.tools.preprocess_kh9`:
- add batch resampling (resampling images in parallel, rather than in serial)

`spymicmac.tools.preprocess_pan`:
- add additional kw arguments to pass to `spymicmac.image.join_hexagon`