### PR TITLE
fix readthedocs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - geoutils
   - matplotlib
   - sphinx
-  - opencv
+  - opencv<4.9.0
   - lxml
   - gdal
   - pyasn1


### PR DESCRIPTION
This PR downgrades `opencv` to < 4.9.0, which fixes the libOpenGL import error caused by `opencv` version 4.10.0