### PR TITLE
improved support for aerial photo processing

### DIFF
--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -257,7 +257,8 @@ def _spike_filter(img, axis):
         window = []
         for ind in inds:
             window.extend(list(range(ind-10, ind+11)))
-        _inds = list(set(window))
+        _inds = np.array(list(set(window)))
+        _inds = _inds[np.logical_and(_inds >= 0, _inds < img_mean.size)]
         img_mean[_inds] = np.mean([img_mean[min(_inds)], img_mean[max(_inds)]])
 
     return img_mean

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -272,7 +272,12 @@ def get_rough_frame(img, fact=10):
     :param int fact: the scaling factor for the low-resolution image (default: 10)
     :return: **xmin**, **xmax**, **ymin**, **ymax** (*float*) -- the left, right, top, and bottom indices for the rough border.
     """
-    img_lowres = resample.downsample(img, fact=fact)
+    img_lowres = filters.gaussian(resample.downsample(img, fact=fact), 4)
+    aspect = min(img.shape) / max(img.shape)
+    if aspect > 0.75:
+        lower, upper = 0.1, 0.9
+    else:
+        lower, upper = 0.2, 0.8
 
     rowmean = _spike_filter(img_lowres, axis=0)
     smooth_row = _moving_average(rowmean, n=5)
@@ -297,17 +302,21 @@ def get_rough_frame(img, fact=10):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=20, threshold_rel=0.25, num_peaks=2).flatten()
-    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=20, threshold_rel=0.25, num_peaks=2).flatten()
+    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=int(0.005 * smooth_col.size),
+                               threshold_rel=0.25).flatten()
+    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=int(0.005 * smooth_col.size),
+                                 threshold_rel=0.25).flatten()
 
-    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=20, threshold_rel=0.25, num_peaks=2).flatten()
-    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=20, threshold_rel=0.25, num_peaks=2).flatten()
+    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=int(0.005 * smooth_row.size),
+                               threshold_rel=0.25).flatten()
+    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=int(0.005 * smooth_row.size),
+                                 threshold_rel=0.25).flatten()
 
-    left_ind = np.max(row_peaks[np.where(row_peaks < 0.2 * rowmean.size)[0]], initial=-1e10)
-    right_ind = np.min(row_troughs[np.where(row_troughs > 0.8 * rowmean.size)[0]], initial=1e10)
+    left_ind = np.max(row_peaks[np.where(row_peaks < lower * rowmean.size)[0]], initial=-1e10)
+    right_ind = np.min(row_troughs[np.where(row_troughs > upper * rowmean.size)[0]], initial=1e10)
 
-    top_ind = np.max(col_peaks[np.where(col_peaks < 0.2 * colmean.size)[0]], initial=-1e10)
-    bot_ind = np.min(col_troughs[np.where(col_troughs > 0.8 * colmean.size)[0]], initial=1e10)
+    top_ind = np.max(col_peaks[np.where(col_peaks < lower * colmean.size)[0]], initial=-1e10)
+    bot_ind = np.min(col_troughs[np.where(col_troughs > upper * colmean.size)[0]], initial=1e10)
 
     # xmin = 10 * (sorted_row[min_ind] + 1)
     # xmax = 10 * (sorted_row[max_ind] + 1)

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -148,6 +148,14 @@ def _get_all_fid_matches(img, templates, measures_cam, thresh_tol=0.9, min_dist=
 
 def _filter_fid_matches(coords_all, measures_cam):
     nfids = len(coords_all.gcp.unique())
+    if nfids < len(measures_cam) - 1:
+        print(f'Unable to find a transformation with only {nfids} points.')
+        inds = []
+        for fid in coords_all.gcp.unique():
+            inds.append((coords_all['gcp'] == fid).argmax())
+
+        return coords_all.loc[inds]
+
     combs = list(itertools.combinations(coords_all.index, nfids))
 
     filtered_combs = [list(c) for c in combs if len(set(coords_all.loc[list(c), 'gcp'].to_list())) == nfids]

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -561,11 +561,8 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
     """
     assert model.upper() in ['RC5', 'RC5A', 'RC8', 'RC10'], "model must be one of [RC5, RC5A, RC8, RC10]"
     assert data_strip in ['left', 'right', 'top', 'bot'], "data_strip must be one of [left, right, top, bot]"
-    if model.upper() == 'RC5':
-        fids = [f'P{n}' for n in range(1, 5)]
-        # TODO: replace with dark cross inscribed in circle
-        templates = 4 * [_wild_corner(size, model, circle_size, ring_width, width=width, gap=gap)]
-    elif model.upper() in ['RC5A', 'RC8']:
+
+    if model.upper() in ['RC5', 'RC5A', 'RC8']:
         fids = [f'P{n}' for n in range(1, 5)]
         templates = 4 * [_wild_corner(size, model, circle_size, ring_width, width=width, gap=gap)]
     else:

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -468,7 +468,7 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, circle_si
         angle = np.deg2rad(90)
 
     tdict = dict(zip(fids, templates))
-    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, **kwargs)
+    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, use_frame=False, **kwargs)
 
 
 def cross_template(shape, width=3, angle=None):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -238,6 +238,7 @@ def fix_measures_xml(fn_img):
 
     measures_img.reset_index(inplace=True)
     measures_img.rename(columns={'name': 'gcp', 'j': 'im_col', 'i': 'im_row'}, inplace=True)
+    measures_img.dropna(subset=['im_col', 'im_row'], inplace=True)
 
     micmac.write_measures_im(measures_img, fn_img)
 

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -129,8 +129,8 @@ def _get_all_fid_matches(img, templates, measures_cam, thresh_tol=0.9, min_dist=
 
         coords += templ.shape[0] / 2 - 0.5
 
-        coords[:, 1] += row['rough_j'] - jsize[0]
-        coords[:, 0] += row['rough_i'] - isize[0]
+        coords[:, 1] += np.round(row['rough_j']) - jsize[0]
+        coords[:, 0] += np.round(row['rough_i']) - isize[0]
 
         these_coords = pd.DataFrame()
         these_coords['im_col'] = coords[:, 1]
@@ -153,14 +153,14 @@ def _filter_fid_matches(coords_all, measures_cam):
         these_meas = coords_all.loc[c].set_index('gcp').join(measures_cam)
 
         model, inliers = ransac((these_meas[['im_col', 'im_row']].values, these_meas[['j', 'i']].values),
-                                AffineTransform, min_samples=nfids-1, residual_threshold=1)
+                                AffineTransform, min_samples=nfids-1, residual_threshold=2)
         resids.append(model.residuals(these_meas[['im_col', 'im_row']].values,
                                       these_meas[['j', 'i']].values).mean())
 
     best = coords_all.loc[filtered_combs[np.argmin(resids)]].set_index('gcp').join(measures_cam)
 
     model, inliers = ransac((best[['im_col', 'im_row']].values, best[['j', 'i']].values),
-                            AffineTransform, min_samples=nfids - 1, residual_threshold=1)
+                            AffineTransform, min_samples=nfids - 1, residual_threshold=2)
 
     if np.count_nonzero(inliers) < nfids:
         for fid, row in best.loc[~inliers].iterrows():

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -984,7 +984,7 @@ def find_reseau_grid(fn_img, csize=361, return_val=False):
     this_out = os.path.splitext(fn_img)[0]
     fig.savefig(os.path.join('match_imgs', this_out + '_matches.png'), bbox_inches='tight', dpi=200)
 
-    micmac.write_auto_gcps(grid_df, fn_img)
+    micmac.write_measures_im(grid_df, fn_img)
 
     if return_val:
         return grid_df

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -432,7 +432,7 @@ def _wild_corner(size, model, circle_size, ring_width):
         if circle_size is not None:
             template = inscribed_cross(circle_size, size, angle=45)
         else:
-            template = cross_template(size, width=1, angle=45, no_border=True)
+            template = cross_template(size, width=3, angle=45, no_border=True)
 
             rows, cols = template.shape
             _width = 9

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -268,7 +268,7 @@ def inscribed_cross(size, cross_size, width=3, angle=45):
     """
 
     circle = 255 * disk(size)
-    cross = cross_template(cross_size, width=width, angle=angle)
+    cross = cross_template(cross_size, width=width, angle=angle, no_border=True)
     cross[cross > 0.8] = 255
 
     pad = int((circle.shape[0] - cross.shape[0]) / 2)
@@ -356,7 +356,7 @@ def match_fairchild(fn_img, size, model, data_strip, fn_cam=None, dot_size=4, **
 
 
 def _zeiss_corner(size):
-    return 4 * [cross_template(size)]
+    return 4 * [cross_template(size, no_border=True)]
 
 
 def _zeiss_midside(size, dot_size):
@@ -410,7 +410,7 @@ def _wild_corner(size, model, circle_size, ring_width):
         if circle_size is not None:
             template = inscribed_cross(circle_size, size, angle=45)
         else:
-            template = cross_template(size, width=1, angle=45)
+            template = cross_template(size, width=1, angle=45, no_border=True)
             template[template > 0.8] = 255
     else:
         template = wagon_wheel(size, width=3, circle_size=circle_size, circle_width=ring_width, angle=target_angle)
@@ -471,13 +471,14 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, circle_si
     return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, use_frame=False, **kwargs)
 
 
-def cross_template(shape, width=3, angle=None):
+def cross_template(shape, width=3, angle=None, no_border=False):
     """
     Create a cross-shaped template for matching reseau or fiducial marks.
 
     :param int shape: the output shape of the template
     :param int width: the width of the cross at the center of the template (default: 3 pixels).
     :param float angle: the angle to rotate the template by (default: None).
+    :param no_border flat: do not include a border around the cross (default: False)
     :return: **cross** (*array-like*) -- the cross template
     """
     if isinstance(shape, int):
@@ -502,8 +503,9 @@ def cross_template(shape, width=3, angle=None):
     half_w = int((width - 1) / 2)
 
     cross = np.zeros((rows, cols))
-    cross[half_r - half_w - 1:half_r + half_w + 2:width + 1, :] = 2
-    cross[:, half_c - half_w - 1:half_c + half_w + 2:width + 1] = 2
+    if not no_border:
+        cross[half_r - half_w - 1:half_r + half_w + 2:width + 1, :] = 2
+        cross[:, half_c - half_w - 1:half_c + half_w + 2:width + 1] = 2
 
     cross[half_r - half_w:half_r + half_w + 1, :] = 1
     cross[:, half_c - half_w:half_c + half_w + 1] = 1

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -76,6 +76,16 @@ def find_fiducials(fn_img, templates, fn_cam=None, thresh_tol=0.9, npeaks=5, min
         res = cv2.matchTemplate(subimg.astype(np.uint8), templ.astype(np.uint8), cv2.TM_CCORR_NORMED)
 
         coords = peak_local_max(res, threshold_rel=thresh_tol, min_distance=min_dist, num_peaks=npeaks).astype(float)
+
+        # get subpixel by looking in a small window around each "peak"
+        for ind, coord in enumerate(coords):
+            ii, jj = coord.astype(int)
+            subres, _, _ = make_template(res, (ii, jj), half_size=3)
+
+            sub_x, sub_y = _subpixel(subres, how='max')
+            coords[ind, 1] += sub_x
+            coords[ind, 0] += sub_y
+
         coords += templ.shape[0] / 2 - 0.5
 
         coords[:, 1] += row['rough_j'] - jsize[0]

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -12,7 +12,7 @@ from skimage import morphology, io, filters
 from skimage.morphology import binary_dilation, disk
 from skimage.measure import ransac
 from skimage.feature import peak_local_max
-from skimage.transform import EuclideanTransform, SimilarityTransform
+from skimage.transform import AffineTransform, EuclideanTransform, SimilarityTransform
 from scipy.interpolate import RectBivariateSpline as RBS
 from scipy import ndimage
 import numpy as np
@@ -780,7 +780,7 @@ def match_reseau_grid(img, coords, cross):
         grid_df.loc[ind, 'dist'] = gridpt.distance(matchpt)
 
     model, inliers = ransac((grid_df[['grid_j', 'grid_i']].values, grid_df[['match_j', 'match_i']].values),
-                            SimilarityTransform, min_samples=10, residual_threshold=grid_df.dist.median(), max_trials=5000)
+                            AffineTransform, min_samples=10, residual_threshold=grid_df.dist.median(), max_trials=5000)
     grid_df.loc[~inliers, 'dist'] = np.nan
     grid_df.loc[~inliers, 'match_j'] = np.nan
     grid_df.loc[~inliers, 'match_i'] = np.nan
@@ -931,7 +931,7 @@ def find_reseau_grid(fn_img, csize=361, return_val=False):
     grid_df = find_crosses(img, cross)
 
     model, inliers = ransac((grid_df[['grid_j', 'grid_i']].values, grid_df[['match_j', 'match_i']].values),
-                            SimilarityTransform, min_samples=10, residual_threshold=10, max_trials=5000)
+                            AffineTransform, min_samples=10, residual_threshold=10, max_trials=5000)
     grid_df['resid'] = model.residuals(grid_df.dropna()[['grid_j', 'grid_i']].values,
                                        grid_df.dropna()[['match_j', 'match_i']].values)
 

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -516,7 +516,7 @@ def match_zeiss_rmk(fn_img, size, dot_size, data_strip='left', fn_cam=None, corn
     return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, **kwargs)
 
 
-def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None, vgap=None):
+def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None, vgap=None, dot_size=None):
 
     target_angle = 45
     if model.upper() in ['RC5']:
@@ -544,6 +544,9 @@ def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None,
             template[half_r - half_v:half_r + half_v + 1, :] = 0
             template[:, half_c - half_h:half_c + half_h + 1] = 0
 
+        if dot_size is not None:
+            template += padded_dot(size, dot_size)
+
         template[template > 0.8] = 255
     else:
         template = wagon_wheel(size, width=width, circle_size=circle_size, circle_width=ring_width, angle=target_angle)
@@ -564,7 +567,7 @@ def _wild_midside(size, model, circle_size, ring_width):
 
 
 def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, circle_size=None, ring_width=7, gap=9,
-                  vgap=None, **kwargs):
+                  vgap=None, dot_size=None, **kwargs):
     """
     Match the fiducial locations for a Wild RC-style camera (4 cross/bulls-eye markers in the corner, possibly
     4 bulls-eye markers along the sides).
@@ -582,6 +585,7 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
         models.
     :param int gap: the width, in pixels, of the gap in the middle of the cross (default: 9)
     :param int vgap: the height, in pixels, of the gap in the middle of the cross (default: same as gap)
+    :param int dot_size: the half-size, in pixels, of the dot in the middle of the cross (default: no dot)
     :param kwargs: additional keyword arguments to pass to matching.find_fiducials()
     :return:
     """
@@ -590,11 +594,12 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
 
     if model.upper() in ['RC5', 'RC5A', 'RC8']:
         fids = [f'P{n}' for n in range(1, 5)]
-        templates = 4 * [_wild_corner(size, model, circle_size, ring_width, width=width, gap=gap, vgap=vgap)]
+        templates = 4 * [_wild_corner(size, model, circle_size, ring_width, width=width,
+                                      gap=gap, vgap=vgap, dot_size=dot_size)]
     else:
         fids = [f'P{n}' for n in range(1, 9)]
         stempl = _wild_midside(size, model)
-        ctempl = _wild_corner(size, model, circle_size, ring_width, width=width, gap=gap, vgap=vgap)
+        ctempl = _wild_corner(size, model, circle_size, ring_width, width=width, gap=gap, vgap=vgap, dot_size=dot_size)
         templates = 4 * [ctempl] + 4 * [stempl]
 
     locs = ['left', 'top', 'right', 'bot']

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -81,10 +81,11 @@ def find_fiducials(fn_img, templates, fn_cam=None, thresh_tol=0.9, npeaks=5, min
     # now, drop any duplicated values - if we have these, we need to replace/estimate
     # coords_all = coords_all.sort_values('resid').drop_duplicates(subset=['im_col', 'im_row']).sort_values('gcp')
     if len(coords_all) < len(measures_cam):
-        print('One or more markers could not be found. \nAttempting to predict location(s) using affine transformation')
+        print('One or more markers could not be found.')
         # coords_all = _fix_fiducials(coords_all, measures_cam)
-
-    _, residuals = _get_residuals(coords_all, measures_cam)
+        residuals = np.array(len(coords_all) * [np.nan])
+    else:
+        _, residuals = _get_residuals(coords_all, measures_cam)
 
     print('Mean residual: {:.2f} pixels'.format(residuals.mean()))
 

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -206,14 +206,18 @@ def _fix_fiducials(coords, measures_cam):
     return coords.reset_index()
 
 
-def fix_measures_xml(fn_img):
+def fix_measures_xml(fn_img, fn_cam=None):
     """
     Use an affine transformation to estimate locations of any missing fiducial markers in an image. Output written to
         Ori-InterneScan/MeasuresIm-{fn_img}.xml
 
     :param str fn_img: the filename of the image.
+    :param str fn_cam: the Measures file to use. Defaults to Ori-InterneScan/MeasuresCamera.xml.
     """
-    measures_cam = micmac.parse_im_meas(os.path.join('Ori-InterneScan', 'MeasuresCamera.xml')).set_index('name')
+    if fn_cam is None:
+        fn_cam = os.path.join('Ori-InterneScan', 'MeasuresCamera.xml')
+
+    measures_cam = micmac.parse_im_meas(fn_cam).set_index('name')
     measures_img = micmac.parse_im_meas(os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml')).set_index('name')
 
     meas = measures_cam.join(measures_img, lsuffix='_cam', rsuffix='_img').dropna()
@@ -517,7 +521,7 @@ def match_zeiss_rmk(fn_img, size, dot_size, data_strip='left', fn_cam=None, corn
     return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, **kwargs)
 
 
-def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None, vgap=None, dot_size=None):
+def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None, vgap=None, dot_size=None, pad=10):
 
     target_angle = 45
     if model.upper() in ['RC5']:
@@ -552,7 +556,7 @@ def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=None,
     else:
         template = wagon_wheel(size, width=width, circle_size=circle_size, circle_width=ring_width, angle=target_angle)
 
-    return template
+    return np.pad(template, pad)
 
 
 def _wild_midside(size, model, circle_size, ring_width):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -99,7 +99,7 @@ def _get_all_fid_matches(img, templates, measures_cam, thresh_tol=0.9, min_dist=
 
     for fid, row in measures_cam.iterrows():
         templ = templates[fid]
-        tsize = int(min(0.075 * np.array(img.shape)))
+        tsize = int(min(0.05 * np.array(img.shape)))
         if int(tsize/4) & 1:
             bsize = int(tsize/4)
         else:
@@ -254,8 +254,21 @@ def _get_rough_locs(meas, img=None):
 
     else:
         left, right, top, bot = image.get_rough_frame(img)
-        x_mid = left + (right - left) / 2
-        y_mid = top + (bot - top) / 2
+        left = max(0, left)
+        right = min(img.shape[1], right)
+        top = max(0, top)
+        bot = min(img.shape[0], bot)
+
+        lr = (right - left)
+        tb = (bot - top)
+
+        x_mid = left + lr / 2
+        y_mid = top + tb / 2
+
+        left += 0.075 * lr
+        right -= 0.075 * lr
+        top += 0.075 * tb
+        bot -= 0.075 * tb
 
         scaled['j'] = scaled['j'] * (right - left) + left
         scaled['i'] = scaled['i'] * (bot - top) + top
@@ -543,7 +556,7 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
         angle = np.deg2rad(90)
 
     tdict = dict(zip(fids, templates))
-    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, use_frame=False, **kwargs)
+    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, **kwargs)
 
 
 def cross_template(shape, width=3, angle=None, no_border=False):
@@ -553,7 +566,7 @@ def cross_template(shape, width=3, angle=None, no_border=False):
     :param int shape: the output shape of the template
     :param int width: the width of the cross at the center of the template (default: 3 pixels).
     :param float angle: the angle to rotate the template by (default: None).
-    :param no_border flat: do not include a border around the cross (default: False)
+    :param bool no_border: do not include a border around the cross (default: False)
     :return: **cross** (*array-like*) -- the cross template
     """
     if isinstance(shape, int):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -512,8 +512,10 @@ def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=9):
     target_angle = 45
     if model.upper() in ['RC5']:
         if circle_size is None:
-            circle_size = _odd(int(1.4 * size))  # approximate but probably good enough
-            template = inscribed_cross(circle_size, size, angle=45)
+            circle_size = _odd(int(1.2 * size))  # approximate but probably good enough
+        template = inscribed_cross(circle_size, size, angle=45)
+        template = np.pad(template, 20)
+
     elif model.upper() in ['RC5A', 'RC8']:
         template = cross_template(size, width=width, angle=45, no_border=True)
 

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -572,7 +572,7 @@ def _wild_midside(size, model, circle_size, ring_width):
 
 
 def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, circle_size=None, ring_width=7, gap=9,
-                  vgap=None, dot_size=None, **kwargs):
+                  vgap=None, dot_size=None, pad=10, **kwargs):
     """
     Match the fiducial locations for a Wild RC-style camera (4 cross/bulls-eye markers in the corner, possibly
     4 bulls-eye markers along the sides).
@@ -591,6 +591,7 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
     :param int gap: the width, in pixels, of the gap in the middle of the cross (default: 9)
     :param int vgap: the height, in pixels, of the gap in the middle of the cross (default: same as gap)
     :param int dot_size: the half-size, in pixels, of the dot in the middle of the cross (default: no dot)
+    :param int pad: the size of the padding around the outside of the cross to include (default: 10 pixels)
     :param kwargs: additional keyword arguments to pass to matching.find_fiducials()
     :return:
     """
@@ -600,11 +601,12 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
     if model.upper() in ['RC5', 'RC5A', 'RC8']:
         fids = [f'P{n}' for n in range(1, 5)]
         templates = 4 * [_wild_corner(size, model, circle_size, ring_width, width=width,
-                                      gap=gap, vgap=vgap, dot_size=dot_size)]
+                                      gap=gap, vgap=vgap, dot_size=dot_size, pad=pad)]
     else:
         fids = [f'P{n}' for n in range(1, 9)]
         stempl = _wild_midside(size, model)
-        ctempl = _wild_corner(size, model, circle_size, ring_width, width=width, gap=gap, vgap=vgap, dot_size=dot_size)
+        ctempl = _wild_corner(size, model, circle_size, ring_width, width=width,
+                              gap=gap, vgap=vgap, dot_size=dot_size, pad=pad)
         templates = 4 * [ctempl] + 4 * [stempl]
 
     locs = ['left', 'top', 'right', 'bot']

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -164,11 +164,14 @@ def _filter_fid_matches(coords_all, measures_cam):
         these_meas = coords_all.loc[c].set_index('gcp').join(measures_cam)
 
         model, inliers = ransac((these_meas[['im_col', 'im_row']].values, these_meas[['j', 'i']].values),
-                                SimilarityTransform, min_samples=nfids-1, residual_threshold=2, max_trials=20)
-        resids.append(model.residuals(these_meas[['im_col', 'im_row']].values,
-                                      these_meas[['j', 'i']].values).mean())
+                                SimilarityTransform, min_samples=nfids-1, residual_threshold=10, max_trials=20)
+        try:
+            resids.append(model.residuals(these_meas[['im_col', 'im_row']].values,
+                                          these_meas[['j', 'i']].values).mean())
+        except AttributeError:
+            resids.append(np.nan)
 
-    return coords_all.loc[filtered_combs[np.argmin(resids)]]
+    return coords_all.loc[filtered_combs[np.nanargmin(resids)]]
 
 
 def _get_scale(scale, units):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -99,7 +99,9 @@ def _get_all_fid_matches(img, templates, measures_cam, thresh_tol=0.9, min_dist=
 
     for fid, row in measures_cam.iterrows():
         templ = templates[fid]
-        tsize = int(min(0.05 * np.array(img.shape)))
+        tsize = int(min(0.075 * np.array([measures_cam.rough_j.max() - measures_cam.rough_j.min(),
+                                          measures_cam.rough_i.max() - measures_cam.rough_i.min()])))
+
         if int(tsize/4) & 1:
             bsize = int(tsize/4)
         else:
@@ -253,7 +255,7 @@ def _get_rough_locs(meas, img=None):
         rough_pts = [Point(x, y) for x, y in zip(rough_x.flatten(), rough_y.flatten())]
 
     else:
-        left, right, top, bot = image.get_rough_frame(img)
+        left, right, top, bot = image.get_rough_frame(img, fact=1)
         left = max(0, left)
         right = min(img.shape[1], right)
         top = max(0, top)
@@ -265,10 +267,10 @@ def _get_rough_locs(meas, img=None):
         x_mid = left + lr / 2
         y_mid = top + tb / 2
 
-        left += 0.075 * lr
-        right -= 0.075 * lr
-        top += 0.075 * tb
-        bot -= 0.075 * tb
+        left += 0.025 * lr
+        right -= 0.025 * lr
+        top += 0.025 * tb
+        bot -= 0.025 * tb
 
         scaled['j'] = scaled['j'] * (right - left) + left
         scaled['i'] = scaled['i'] * (bot - top) + top

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -112,9 +112,13 @@ def _get_all_fid_matches(img, templates, measures_cam, thresh_tol=0.9, min_dist=
     for fid, row in measures_cam.iterrows():
         templ = templates[fid]
         tsize = int(min(0.075 * np.array(img.shape)))
+        if int(tsize/4) & 1:
+            bsize = int(tsize/4)
+        else:
+            bsize = int(tsize/4) + 1
 
         subimg, isize, jsize = make_template(img, (row['rough_i'], row['rough_j']), half_size=tsize)
-        thresh = subimg > filters.threshold_local(subimg, block_size=21)
+        thresh = subimg > filters.threshold_local(subimg, block_size=bsize)
         res = cv2.matchTemplate(thresh.astype(np.uint8), templ.astype(np.uint8), cv2.TM_CCORR_NORMED)
 
         coords = peak_local_max(res, threshold_rel=thresh_tol, min_distance=min_dist, num_peaks=npeaks).astype(float)
@@ -158,19 +162,19 @@ def _filter_fid_matches(coords_all, measures_cam):
         resids.append(model.residuals(these_meas[['im_col', 'im_row']].values,
                                       these_meas[['j', 'i']].values).mean())
 
-    best = coords_all.loc[filtered_combs[np.argmin(resids)]].set_index('gcp').join(measures_cam)
+    # best = coords_all.loc[filtered_combs[np.argmin(resids)]].set_index('gcp').join(measures_cam)
 
-    model, inliers = ransac((best[['im_col', 'im_row']].values, best[['j', 'i']].values),
-                            AffineTransform, min_samples=nfids - 1, residual_threshold=2, max_trials=20)
+    # model, inliers = ransac((best[['im_col', 'im_row']].values, best[['j', 'i']].values),
+    #                         AffineTransform, min_samples=nfids - 1, residual_threshold=2, max_trials=20)
 
-    if np.count_nonzero(inliers) < nfids:
-        for fid, row in best.loc[~inliers].iterrows():
-            print(f'Replacing {fid} with estimated location.')
-            pt = model.inverse(row[['j', 'i']].values)[0]
-            best.loc[fid, 'im_col'] = pt[0]
-            best.loc[fid, 'im_row'] = pt[1]
+    # if np.count_nonzero(inliers) < nfids:
+    #     for fid, row in best.loc[~inliers].iterrows():
+    #         print(f'Replacing {fid} with estimated location.')
+    #         pt = model.inverse(row[['j', 'i']].values)[0]
+    #         best.loc[fid, 'im_col'] = pt[0]
+    #         best.loc[fid, 'im_row'] = pt[1]
 
-    return best[['im_col', 'im_row']].reset_index()
+    return coords_all.loc[filtered_combs[np.argmin(resids)]]
 
 
 def _get_scale(scale, units):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -506,12 +506,13 @@ def _wild_corner(size, model, circle_size=None, ring_width=7, width=3, gap=9):
 
         rows, cols = template.shape
 
-        half_r = int((rows - 1) / 2)
-        half_c = int((rows - 1) / 2)
-        half_w = int((gap - 1) / 2)
+        if gap is not None:
+            half_r = int((rows - 1) / 2)
+            half_c = int((rows - 1) / 2)
+            half_w = int((gap - 1) / 2)
 
-        template[half_r - half_w:half_r + half_w + 1, :] = 0
-        template[:, half_c - half_w:half_c + half_w + 1] = 0
+            template[half_r - half_w:half_r + half_w + 1, :] = 0
+            template[:, half_c - half_w:half_c + half_w + 1] = 0
 
         template[template > 0.8] = 255
     else:

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -568,17 +568,12 @@ def match_wild_rc(fn_img, size, model, data_strip='left', fn_cam=None, width=3, 
         ctempl = _wild_corner(size, model, circle_size, ring_width, width=width, gap=gap)
         templates = 4 * [ctempl] + 4 * [stempl]
 
-    if data_strip == 'left':
-        angle = None
-    elif data_strip == 'top':
-        angle = np.deg2rad(-90)
-    elif data_strip == 'right':
-        angle = np.deg2rad(180)
-    else:
-        angle = np.deg2rad(90)
+    locs = ['left', 'top', 'right', 'bot']
+    angles = [None, np.deg2rad(-90), np.deg2rad(180), np.deg2rad(90)]
+    ldict = dict(zip(locs, angles))
 
     tdict = dict(zip(fids, templates))
-    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=angle, **kwargs)
+    return find_fiducials(fn_img, tdict, fn_cam=fn_cam, angle=ldict[data_strip], **kwargs)
 
 
 def cross_template(shape, width=3, angle=None, no_border=False):

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -756,7 +756,7 @@ def find_empty_homol(dir_homol='Homol'):
     :param str dir_homol: the Homol directory to search in (default: Homol)
     """
     pastis = glob('Pastis*', root_dir=dir_homol)
-    empty = [d.split('Pastis')[-1] for d in pastis if len(glob('OIS*.tif.dat', root_dir=os.path.join('Homol', d))) == 0]
+    empty = [d.split('Pastis')[-1] for d in pastis if len(glob('*.dat', root_dir=os.path.join('Homol', d))) == 0]
 
     os.makedirs('EmptyMatch', exist_ok=True)
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -207,6 +207,31 @@ def parse_im_meas(fn_meas):
     return meas_df
 
 
+def write_measures_im(meas_df, fn_img):
+    """
+    Create a MeasuresIm xml file with
+
+    :param DataFrame meas_df: a DataFrame of image measures, with [gcp, im_col, im_row] columns
+    :param str fn_img: the filename of the image.
+    :return:
+    """
+    os.makedirs('Ori-InterneScan', exist_ok=True)
+
+    # write the measures
+    E = builder.ElementMaker()
+    ImMes = E.MesureAppuiFlottant1Im(E.NameIm(fn_img))
+
+    pt_els = get_im_meas(meas_df, E)
+    for p in pt_els:
+        ImMes.append(p)
+
+    outxml = E.SetOfMesureAppuisFlottants(ImMes)
+
+    tree = etree.ElementTree(outxml)
+    tree.write(os.path.join('Ori-InterneScan', 'MeasuresIm-' + fn_img + '.xml'), pretty_print=True,
+               xml_declaration=True, encoding="utf-8")
+
+
 def generate_measures_files(joined=False):
     """
     Create id_fiducial.txt, MeasuresCamera.xml, and Tmp-SL-Glob.xml files for KH-9 Hexagon images.

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -272,7 +272,7 @@ def create_measurescamera_xml(fn_csv, ori='InterneScan', translate=False, name='
     """
     Create a MeasuresCamera.xml file from a csv of fiducial marker locations.
 
-    :param str fn_csv: the filename of the CSV file.
+    :param str|DataFrame fn_csv: the filename of the CSV file, or a pandas DataFrame.
     :param str ori: the Ori directory to write the MeasuresCamera.xml file to. Defaults to (Ori-)InterneScan.
     :param bool translate: translate coordinates so that the origin is the upper left corner, rather than the principal
         point
@@ -280,7 +280,11 @@ def create_measurescamera_xml(fn_csv, ori='InterneScan', translate=False, name='
     :param str x: the column name in the csv file corresponding to the image x location [im_col]
     :param str y: the column name in the csv file corresponding to the image y location [im_row]
     """
-    fids = pd.read_csv(fn_csv)
+    assert type(fn_csv) in [pd.core.frame.DataFrame, str], "fn_csv must be one of [str, DataFrame]"
+    if isinstance(fn_csv, str):
+        fids = pd.read_csv(fn_csv)
+    else:
+        fids = fn_csv
 
     # if coordinates are relative to the principal point,
     # convert them to be relative to the upper left corner

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -757,7 +757,7 @@ def find_empty_homol(imlist=None, dir_homol='Homol', pattern='OIS*.tif'):
     :param str dir_homol: the Homol directory to search in (default: Homol)
     :param str pattern: the search pattern to use to find images (default: OIS*.tif)
     """
-    pastis = glob('Pastis*', root_dir=dir_homol)
+
     if imlist is None:
         imlist = glob(pattern)
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -209,7 +209,7 @@ def parse_im_meas(fn_meas):
 
 def write_measures_im(meas_df, fn_img):
     """
-    Create a MeasuresIm xml file with
+    Create a MeasuresIm xml file for an image.
 
     :param DataFrame meas_df: a DataFrame of image measures, with [gcp, im_col, im_row] columns
     :param str fn_img: the filename of the image.

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -45,6 +45,7 @@ def write_neighbour_images(imlist, fprints=None, nameField='ID', prefix='OIS-Ree
     else:
         fprints = fprints[fprints[nameField].isin(imlist)]
 
+    fprints.reset_index(inplace=True)  # do this to ensure that strtree indices are correct
     s = STRtree([f for f in fprints['geometry'].values])
 
     for i, row in fprints.iterrows():

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -895,13 +895,14 @@ def _generate_glob(fn_ids):
     tree.write('Tmp-SL-Glob.xml', pretty_print=True, xml_declaration=True, encoding="utf-8")
 
 
-def batch_saisie_fids(imlist, flavor='qt', fn_cam=None):
+def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True):
     """
     Run SaisieAppuisInit to locate the fiducial markers for a given list of images.
 
     :param list imlist: the list of image filenames.
     :param str flavor: which version of SaisieAppuisInit to run. Must be one of [qt, og] (default: qt)
     :param str fn_cam: the filename for the MeasuresCamera.xml file (default: Ori-InterneScan/MeasuresCamera.xml)
+    :param bool clean: remove any image files in Tmp-SaisieAppuis
     """
     assert flavor in ['qt', 'og'], "flavor must be one of [qt, og]"
 
@@ -931,8 +932,14 @@ def batch_saisie_fids(imlist, flavor='qt', fn_cam=None):
 
     for fn_img in imlist:
         if os.path.exists(os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml')):
+            if clean:
+                tmplist = glob('*' + fn_img + '*', root_dir='Tmp-SaisieAppuis')
+                for fn_tmp in tmplist:
+                    os.remove(os.path.join('Tmp-SaisieAppuis', fn_tmp))
+
             shutil.copy(os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml'),
                         f'MeasuresIm-{fn_img}-S2D.xml')
+
             shutil.copy('Tmp-SL-Glob.xml',
                         os.path.join('Tmp-SaisieAppuis', f'Tmp-SL-Glob-MeasuresIm-{fn_img}.xml'))
 

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -6,7 +6,7 @@ import multiprocessing as mp
 import PIL.Image
 from osgeo import gdal
 from skimage import io
-from skimage.transform import ProjectiveTransform, warp
+from skimage.transform import SimilarityTransform, warp
 from scipy import ndimage
 import numpy as np
 from spymicmac import image, micmac, matching
@@ -191,9 +191,9 @@ def align_image_borders(fn_left, fn_right, border):
     mask_right = _border_mask(right, border)
 
 
-def resample_projective(fn_img, scale, fn_cam=None, nproc=1):
+def resample_similarity(fn_img, scale, fn_cam=None, nproc=1):
     """
-    Resample image(s) using a projective transform.
+    Resample image(s) using a similarity transform.
 
     :param str|list fn_img: the filename, or a list of filenames, of the image(s)
     :param float scale: the image scale (in mm/pixel) to use
@@ -202,7 +202,7 @@ def resample_projective(fn_img, scale, fn_cam=None, nproc=1):
     :return:
     """
     if type(fn_img) is str:
-        _projective(fn_img=fn_img, scale=scale, fn_cam=fn_cam)
+        _similarity(fn_img=fn_img, scale=scale, fn_cam=fn_cam)
     else:
         if nproc > 1:
             pool = mp.Pool(nproc, maxtasksperchild=1)
@@ -211,19 +211,19 @@ def resample_projective(fn_img, scale, fn_cam=None, nproc=1):
             for d in pool_args:
                 d.update(arg_dict)
 
-            pool.map(_projective_wrapper, pool_args, chunksize=1)
+            pool.map(_similarity_wrapper, pool_args, chunksize=1)
             pool.close()
             pool.join()
         else:
             for fn in fn_img:
-                _projective(fn_img=fn, scale=scale, fn_cam=fn_cam)
+                _similarity(fn_img=fn, scale=scale, fn_cam=fn_cam)
 
 
-def _projective_wrapper(args):
-    _projective(**args)
+def _similarity_wrapper(args):
+    _similarity(**args)
 
 
-def _projective(fn_img=None, scale=None, fn_cam=None):
+def _similarity(fn_img=None, scale=None, fn_cam=None):
     print(fn_img)
     meas = micmac.parse_im_meas(os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml'))
     if fn_cam is None:
@@ -236,7 +236,7 @@ def _projective(fn_img=None, scale=None, fn_cam=None):
 
     joined = meas.set_index('name').join(measures_cam.set_index('name'), lsuffix='_img', rsuffix='_cam')
 
-    model = ProjectiveTransform()
+    model = SimilarityTransform()
     model.estimate(joined[['j_img', 'i_img']].values,
                    joined[['j_cam', 'i_cam']].values)
 


### PR DESCRIPTION
This PR will incorporate the following changes, intended to help improve support for processing scanned/historic aerial photos:

`spymicmac.image`:
- prevent potential `IndexError` in `_spike_filter`
- change default behavior of `get_rough_frame`, based on the aspect ration of the image (air photo vs declassified images)

`spymicmac.matching`:
- change `fn_cam` argument + behavior for `find_fiducials`
- add `threshold`, `dual` options to `find_fiducials` to use a local threshold to help improve matching
- use pairwise similarity transformations to find the best set of candidate matches
- add support for Wild RC5A, RC8 style cameras, add additional arguments for customization

`spymicmac.micmac`:
- add `write_measures_xml`, for convenient writing of MeasuresIm xml files
- improve `estimate_measures_camera` through additional transformation estimation to estimated measures locations
- improve `find_empty_homol` by searching based on images in the current directory, or a provided list of images
- add `find_connected_blocks` to find groups of images that are connected based on their homologues
- add `clean` argument to `batch_saisie_fids`, to remove any temporary files from Tmp-SaisieAppuis

`spymicmac.resample`:
- add `resample_similarity`, to resample images using a similarity transform