### PR TITLE
additional malt arguments

### DIFF
--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -946,16 +946,16 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
     :param str dirmec: the output MEC directory to create (default: MEC-Malt)
     :param str seed_img: a DEM to pass to Malt as DEMInitImg. Note that if seed_img is set, seed_xml
         must also be set. If used, it is recommended to set zoomi to be approximately equal to the DEM resolution -
-        i.e., if the ortho resolution is 5 m and the seed DEM is 10 m, ZoomI should be 4. (default: not used)
+        i.e., if the ortho resolution is 5 m and the seed DEM is 20 m, ZoomI should be 4. (default: not used)
     :param str seed_xml: an XML file corresponding to the seed_img (default: not used)
     :param float resol_terr: the resolution of the output DEM, in ground units (default: computed by mm3d)
     :param float resol_ort: the resolution of the ortho images, relative to the output DEM - e.g., resol_ort=1 means
-        the DEM and Orthoimage have the same resolution (default: 0.5)
+        the DEM and Orthoimage have the same resolution (default: 2.0)
     :param float cost_trans: cost to change from correlation to decorrelation (default: 2.0)
     :param int szw: the half-size of the correlation window to use - e.g., szw=1 means a 3x3 correlation window.
         (default: 2)
-    :param float regul: the regularization factor to use. Lower values mean higher potential variability between adjacent
-        pixels, higher values (up to 1) mean smoother outputs (default: 0.05)
+    :param float regul: the regularization factor to use. Lower values mean higher potential variability between
+        adjacent pixels, higher values (up to 1) mean smoother outputs (default: 0.05)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -934,7 +934,8 @@ def apericloud(ori, img_pattern='OIS.*tif'):
     return p.wait()
 
 
-def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, seed_xml=None):
+def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, seed_xml=None,
+         resol_terr=None, resol_ort=None, cost_trans=None, szw=None, regul=None):
     """
     Run mm3d Malt Ortho.
 
@@ -944,8 +945,17 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
     :param int zoomi: the initial Zoom level to use (default: not set)
     :param str dirmec: the output MEC directory to create (default: MEC-Malt)
     :param str seed_img: a DEM to pass to Malt as DEMInitImg. Note that if seed_img is set, seed_xml
-        must also be set. (default: not used)
+        must also be set. If used, it is recommended to set zoomi to be approximately equal to the DEM resolution -
+        i.e., if the ortho resolution is 5 m and the seed DEM is 10 m, ZoomI should be 4. (default: not used)
     :param str seed_xml: an XML file corresponding to the seed_img (default: not used)
+    :param float resol_terr: the resolution of the output DEM, in ground units (default: computed by mm3d)
+    :param float resol_ort: the resolution of the ortho images, relative to the output DEM - e.g., resol_ort=1 means
+        the DEM and Orthoimage have the same resolution (default: 0.5)
+    :param float cost_trans: cost to change from correlation to decorrelation (default: 2.0)
+    :param int szw: the half-size of the correlation window to use - e.g., szw=1 means a 3x3 correlation window.
+        (default: 2)
+    :param float regul: the regularization factor to use. Lower values mean higher potential variability between adjacent
+        pixels, higher values (up to 1) mean smoother outputs (default: 0.05)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -961,7 +971,7 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
             raise TypeError(f"imlist is not iterable: {imlist}")
 
     args = ['mm3d', 'Malt', 'Ortho', matchstr, ori, 'DirMEC={}'.format(dirmec),
-            'NbVI=2', 'ZoomF={}'.format(zoomf), 'DefCor=0', 'CostTrans=1', 'EZA=1']
+            'NbVI=2', 'ZoomF={}'.format(zoomf), 'DefCor=0', 'EZA=1']
 
     if zoomi is not None:
         args.append('ZoomI={}'.format(zoomi))
@@ -970,6 +980,21 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
         assert seed_xml is not None
         args.append('DEMInitImg=' + seed_img)
         args.append('DEMInitXML=' + seed_xml)
+
+    if resol_terr is not None:
+        args.append('ResolTerrain=' + resol_terr)
+
+    if resol_ort is not None:
+        args.append('ResolOrtho' + resol_ort)
+
+    if cost_trans is not None:
+        args.append('CostTrans=' + cost_trans)
+
+    if szw is not None:
+        args.append('SzW=' + szw)
+
+    if regul is not None:
+        args.append('Regul=' + regul)
 
     p = subprocess.Popen(args, stdin=echo.stdout)
 


### PR DESCRIPTION
This PR adds additional arguments to `spymicmac.micmac.malt`, to enable better tuning of common parameters:
- `SzW`: the size of the correlation window
- `ResolTerrain`: the resolution of the output DEM and orthophotos
- `ResolOrtho`: the relative resolution of the orthophotos and the output DEM
- `CostTrans`: for setting the cost to change from correlation to decorrelation
- `Regul`: for changing the regularization parameter, to make smoother DEMs