### PR TITLE
fix KH-9 MC preprocessing bugs/issues

### DIFF
--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -302,14 +302,14 @@ def get_rough_frame(img, fact=10):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=int(0.005 * smooth_col.size),
+    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=int(0.001 * smooth_col.size),
                                threshold_rel=0.25).flatten()
-    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=int(0.005 * smooth_col.size),
+    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=int(0.001 * smooth_col.size),
                                  threshold_rel=0.25).flatten()
 
-    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=int(0.005 * smooth_row.size),
+    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=int(0.001 * smooth_row.size),
                                threshold_rel=0.25).flatten()
-    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=int(0.005 * smooth_row.size),
+    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=int(0.001 * smooth_row.size),
                                  threshold_rel=0.25).flatten()
 
     # left_ind = np.max(row_peaks[np.where(row_peaks < lower * rowmean.size)[0]], initial=-1e10)

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -95,9 +95,9 @@ def splitter(img, nblocks, overlap=0):
         this_left = []
 
         for j in range(nblocks[1]):
-            lind = max(0, j*new_width-overlap)
+            lind = max(0, j*new_width - overlap - 1)
             rind = min(img.shape[1], (j+1)*new_width + overlap)
-            tind = max(0, i*new_height - overlap)
+            tind = max(0, i*new_height - overlap - 1)
             bind = min(img.shape[0], (i+1)*new_height + overlap)
             this_col.append(img[tind:bind, lind:rind].copy())
             this_top.append(tind)
@@ -455,6 +455,8 @@ def join_halves(left, right, overlap, block_size=None, blend=True, trim=None):
     out_shape = (left.shape[0], left.shape[1] + right.shape[1])
 
     combined_right = warp(right, M, output_shape=out_shape, preserve_range=True, order=3)
+
+    # io.imsave('tmp_right.tif', combined_right.astype(np.uint8))
 
     combined_left = np.zeros(out_shape, dtype=np.uint8)
     combined_left[:, :left.shape[1]] = left

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -280,10 +280,10 @@ def get_rough_frame(img, fact=10):
         lower, upper = 0.2, 0.8
 
     rowmean = _spike_filter(img_lowres, axis=0)
-    smooth_row = _moving_average(rowmean, n=10)
+    smooth_row = _moving_average(rowmean, n=20)
 
     colmean = _spike_filter(img_lowres, axis=1)
-    smooth_col = _moving_average(colmean, n=10)
+    smooth_col = _moving_average(colmean, n=20)
 
     # xmin = 10 * np.where(rowmean > np.percentile(rowmean, 10))[0][0]
     # xmin = 10 * (np.argmax(np.diff(smooth_row)) + 1)

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -277,7 +277,7 @@ def get_rough_frame(img, fact=10):
     if aspect > 0.75:
         lower, upper = 0.1, 0.9
     else:
-        lower, upper = 0.2, 0.8
+        lower, upper = 0.15, 0.85
 
     rowmean = _spike_filter(img_lowres, axis=0)
     smooth_row = _moving_average(rowmean, n=20)
@@ -285,6 +285,11 @@ def get_rough_frame(img, fact=10):
     colmean = _spike_filter(img_lowres, axis=1)
     smooth_col = _moving_average(colmean, n=20)
 
+    lr = int(lower * smooth_row.size)
+    ur = int(upper * smooth_row.size)
+
+    lc = int(lower * smooth_col.size)
+    uc = int(upper * smooth_col.size)
     # xmin = 10 * np.where(rowmean > np.percentile(rowmean, 10))[0][0]
     # xmin = 10 * (np.argmax(np.diff(smooth_row)) + 1)
 
@@ -302,15 +307,15 @@ def get_rough_frame(img, fact=10):
     # of the difference, that's also in the right half of the image
     # min_ind = np.where(sorted_row < 0.2 * sorted_row.size)[0][-1]
     # max_ind = np.where(sorted_row > 0.8 * sorted_row.size)[0][0]
-    col_peaks = peak_local_max(np.diff(smooth_col), min_distance=int(0.001 * smooth_col.size),
+    col_peaks = peak_local_max(np.diff(smooth_col[:lc]), min_distance=int(0.001 * smooth_col.size),
                                threshold_rel=0.25).flatten()
-    col_troughs = peak_local_max(-np.diff(smooth_col), min_distance=int(0.001 * smooth_col.size),
-                                 threshold_rel=0.25).flatten()
+    col_troughs = peak_local_max(-np.diff(smooth_col[uc:]), min_distance=int(0.001 * smooth_col.size),
+                                 threshold_rel=0.25).flatten() + uc
 
-    row_peaks = peak_local_max(np.diff(smooth_row), min_distance=int(0.001 * smooth_row.size),
+    row_peaks = peak_local_max(np.diff(smooth_row[:lr]), min_distance=int(0.001 * smooth_row.size),
                                threshold_rel=0.25).flatten()
-    row_troughs = peak_local_max(-np.diff(smooth_row), min_distance=int(0.001 * smooth_row.size),
-                                 threshold_rel=0.25).flatten()
+    row_troughs = peak_local_max(-np.diff(smooth_row[ur:]), min_distance=int(0.001 * smooth_row.size),
+                                 threshold_rel=0.25).flatten() + ur
 
     # left_ind = np.max(row_peaks[np.where(row_peaks < lower * rowmean.size)[0]], initial=-1e10)
     # right_ind = np.min(row_troughs[np.where(row_troughs > upper * rowmean.size)[0]], initial=1e10)

--- a/src/spymicmac/image.py
+++ b/src/spymicmac/image.py
@@ -314,7 +314,9 @@ def get_rough_frame(img, fact=10):
 
     # left_ind = np.max(row_peaks[np.where(row_peaks < lower * rowmean.size)[0]], initial=-1e10)
     # right_ind = np.min(row_troughs[np.where(row_troughs > upper * rowmean.size)[0]], initial=1e10)
-    left_ind, right_ind = _maximum_sep(row_peaks, row_troughs)
+    # left_ind, right_ind = _maximum_sep(row_peaks, row_troughs)
+    left_ind = _best_sep(row_peaks, smooth_row, False)
+    right_ind = _best_sep(row_troughs, smooth_row, True)
 
     if (right_ind - left_ind) / smooth_row.size < (upper - lower):
         left_ind = np.max(row_peaks[np.where(row_peaks < lower * rowmean.size)[0]], initial=-1e10)
@@ -322,7 +324,9 @@ def get_rough_frame(img, fact=10):
 
     # top_ind = np.max(col_peaks[np.where(col_peaks < lower * colmean.size)[0]], initial=-1e10)
     # bot_ind = np.min(col_troughs[np.where(col_troughs > upper * colmean.size)[0]], initial=1e10)
-    top_ind, bot_ind = _maximum_sep(col_peaks, col_troughs)
+    # top_ind, bot_ind = _maximum_sep(col_peaks, col_troughs)
+    top_ind = _best_sep(col_peaks, smooth_col, False)
+    bot_ind = _best_sep(col_troughs, smooth_col, True)
 
     if (bot_ind - top_ind) / smooth_col.size < (upper - lower):
         top_ind = np.max(col_peaks[np.where(col_peaks < lower * colmean.size)[0]], initial=-1e10)
@@ -348,6 +352,15 @@ def get_rough_frame(img, fact=10):
     # ymax = 10 * (sorted_col[max_ind] + 1)
 
     return xmin, xmax, ymin, ymax
+
+
+def _best_sep(pks, means, trough):
+    davg = min([min(pks), 100, means.size - max(pks)])
+    seps = [means[pk-davg:pk].mean() - means[pk:pk+davg].mean() for pk in pks]
+    if trough:
+        return pks[np.argmax(seps)]
+    else:
+        return pks[np.argmin(seps)]
 
 
 def _maximum_sep(peaks, troughs):

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -1537,7 +1537,7 @@ def match_halves(left, right, overlap, block_size=None):
             continue
 
     model, inliers = ransac((np.array(src_pts), np.array(dst_pts)), EuclideanTransform,
-                        min_samples=10, residual_threshold=2, max_trials=25000)
+                        min_samples=10, residual_threshold=0.2, max_trials=25000)
 
     print('{} tie points found'.format(np.count_nonzero(inliers)))
     return model, np.count_nonzero(inliers)

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -684,7 +684,7 @@ def find_crosses(img, cross):
         res = cv2.matchTemplate(img_inv.astype(np.uint8), cross.astype(np.uint8), cv2.TM_CCORR_NORMED)
 
         these_coords = peak_local_max(res, min_distance=int(1.5*cross.shape[0]),
-                                      threshold_abs=np.median(res)).astype(np.float64)
+                                      threshold_abs=np.quantile(res, 0.6)).astype(np.float64)
 
         these_coords += cross.shape[0] / 2 - 0.5
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1056,8 +1056,8 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
         (default: 2)
     :param float regul: the regularization factor to use. Lower values mean higher potential variability between
         adjacent pixels, higher values (up to 1) mean smoother outputs (default: 0.05)
-    :param bool do_ortho: whether or not to generate the orthoimages (default: True)
-    :param bool do_mec: whether or not to generate an output DEM (default: True)
+    :param bool do_ortho: whether to generate the orthoimages (default: True)
+    :param bool do_mec: whether to generate an output DEM (default: True)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -1222,7 +1222,7 @@ def campari(in_gcps, outdir, img_pattern, sub, dx, ortho_res, allfree=True,
                           'GCP=[{},{},{},{}]'.format(os.path.join(outdir, fn_gcp),
                                                      np.abs(dx) / 4,  # should be correct within 0.25 pixel
                                                      os.path.join(outdir, fn_meas),
-                                                     1),  # best balance for distortion
+                                                     0.5),  # best balance for distortion
                           'SH={}'.format(homol),
                           'AllFree={}'.format(int(allfree))], stdin=echo.stdout)
     p.wait()
@@ -1362,10 +1362,10 @@ def iterate_campari(gcps, out_dir, match_pattern, subscript, dx, ortho_res, fn_g
 
     gcps['camp_xy'] = np.sqrt(gcps.camp_xres ** 2 + gcps.camp_yres ** 2)
 
-    while any([np.any(np.abs(gcps.camp_res - gcps.camp_res.median()) > 3 * register.nmad(gcps.camp_res)),
-               np.any(np.abs(gcps.camp_dist - gcps.camp_dist.median()) > 3 * register.nmad(gcps.camp_dist)),
+    while any([np.any(np.abs(gcps.camp_res - gcps.camp_res.median()) > 2 * register.nmad(gcps.camp_res)),
+               np.any(np.abs(gcps.camp_dist - gcps.camp_dist.median()) > 2 * register.nmad(gcps.camp_dist)),
                gcps.camp_res.max() > 2]) and niter <= max_iter:
-        valid_inds = np.logical_and.reduce((np.abs(gcps.camp_dist - gcps.camp_dist.median()) < 3 * register.nmad(gcps.camp_dist),
+        valid_inds = np.logical_and.reduce((np.abs(gcps.camp_dist - gcps.camp_dist.median()) < 2 * register.nmad(gcps.camp_dist),
                                             gcps.camp_res < gcps.camp_res.max()))
         if np.count_nonzero(valid_inds) < 10:
             break

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1081,7 +1081,7 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
 
     if seed_img is not None:
         assert seed_xml is not None
-        args.append(f'DEMInitImg={seed_img}')
+        args.append(f'DEMInitIMG={seed_img}')
         args.append(f'DEMInitXML={seed_xml}')
 
     if resol_terr is not None:

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1033,7 +1033,7 @@ def apericloud(ori, img_pattern='OIS.*tif'):
 
 
 def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, seed_xml=None,
-         resol_terr=None, resol_ort=None, cost_trans=None, szw=None, regul=None):
+         resol_terr=None, resol_ort=None, cost_trans=None, szw=None, regul=None, do_ortho=True, do_mec=True):
     """
     Run mm3d Malt Ortho.
 
@@ -1054,6 +1054,8 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
         (default: 2)
     :param float regul: the regularization factor to use. Lower values mean higher potential variability between
         adjacent pixels, higher values (up to 1) mean smoother outputs (default: 0.05)
+    :param bool do_ortho: whether or not to generate the orthoimages (default: True)
+    :param bool do_mec: whether or not to generate an output DEM (default: True)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -1069,7 +1071,8 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
             raise TypeError(f"imlist is not iterable: {imlist}")
 
     args = ['mm3d', 'Malt', 'Ortho', matchstr, ori, f'DirMEC={dirmec}',
-            'NbVI=2', f'ZoomF={zoomf}', 'DefCor=0', 'EZA=1']
+            'NbVI=2', f'ZoomF={zoomf}', 'DefCor=0', 'EZA=1',
+            f'DoOrtho={int(do_ortho)}', f'DoMEC={int(do_mec)}']
 
     if zoomi is not None:
         args.append(f'ZoomI={zoomi}')

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1068,31 +1068,31 @@ def malt(imlist, ori, zoomf=1, zoomi=None, dirmec='MEC-Malt', seed_img=None, see
         except TypeError as te:
             raise TypeError(f"imlist is not iterable: {imlist}")
 
-    args = ['mm3d', 'Malt', 'Ortho', matchstr, ori, 'DirMEC={}'.format(dirmec),
-            'NbVI=2', 'ZoomF={}'.format(zoomf), 'DefCor=0', 'EZA=1']
+    args = ['mm3d', 'Malt', 'Ortho', matchstr, ori, f'DirMEC={dirmec}',
+            'NbVI=2', f'ZoomF={zoomf}', 'DefCor=0', 'EZA=1']
 
     if zoomi is not None:
-        args.append('ZoomI={}'.format(zoomi))
+        args.append(f'ZoomI={zoomi}')
 
     if seed_img is not None:
         assert seed_xml is not None
-        args.append('DEMInitImg=' + seed_img)
-        args.append('DEMInitXML=' + seed_xml)
+        args.append(f'DEMInitImg={seed_img}')
+        args.append(f'DEMInitXML={seed_xml}')
 
     if resol_terr is not None:
-        args.append('ResolTerrain=' + resol_terr)
+        args.append(f'ResolTerrain={resol_terr}')
 
     if resol_ort is not None:
-        args.append('ResolOrtho' + resol_ort)
+        args.append(f'ResolOrtho={resol_ort}')
 
     if cost_trans is not None:
-        args.append('CostTrans=' + cost_trans)
+        args.append(f'CostTrans={cost_trans}')
 
     if szw is not None:
-        args.append('SzW=' + szw)
+        args.append(f'SzW={szw}')
 
     if regul is not None:
-        args.append('Regul=' + regul)
+        args.append(f'Regul={regul}')
 
     p = subprocess.Popen(args, stdin=echo.stdout)
 

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -48,7 +48,7 @@ def resample_hex(fn_img, scale, ori='InterneScan'):
 
     out_ds = gdal.Warp('tmp_{}'.format(fn_img), fn_img, xRes=1, yRes=1,
                        outputBounds=[0, 0, all_meas.j_cam.max(), all_meas.i_cam.max()],
-                       resampleAlg=gdal.GRA_Lanczos)
+                       resampleAlg=gdal.GRA_NearestNeighbour)
     meta_shp = '{"shape": ' + '[{}, {}]'.format(out_ds.RasterYSize, out_ds.RasterXSize) + '}'
     out_ds.SetMetadata({'TIFFTAG_IMAGEDESCRIPTION': meta_shp})
     out_ds.FlushCache()

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -50,7 +50,7 @@ def resample_hex(fn_img, scale, ori='InterneScan', alg=gdal.GRA_Bilinear, tps=Tr
     ds = None
 
     options = {'xRes': 1, 'yRes': 1,
-               'outputBounds': [-500, -500, all_meas.j_cam.max() + 500, all_meas.i_cam.max() + 500],
+               'outputBounds': [0, 0, all_meas.j_cam.max(), all_meas.i_cam.max()],
                'resampleAlg': alg,
                'tps': tps}
 

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -24,13 +24,16 @@ def downsample(img, fact=4):
     return np.array(_img.resize((np.array(_img.size) / fact).astype(int), PIL.Image.Resampling.LANCZOS))
 
 
-def resample_hex(fn_img, scale, ori='InterneScan'):
+def resample_hex(fn_img, scale, ori='InterneScan', alg=gdal.GRA_Bilinear, tps=True, order=None):
     """
     Resample a KH-9 Mapping Camera image based on the reseau grid, using gdal.Warp
 
     :param str fn_img: the filename of the image to resample
     :param int scale: the number of pixels per mm of the scanned image
     :param str ori: the Ori directory that contains both MeasuresCamera.xml and MeasuresIm (default: InterneScan)
+    :param alg: the gdal resampling algorithm to use (default: gdal.GRA_Bilinear)
+    :param bool tps: use a thin plate spline transformer to transform based on reseau grid (default: False)
+    :param int order: the order (1-3) of polynomial GCP interpolation (default: not used)
     """
     cam_meas = micmac.parse_im_meas(os.path.join('Ori-{}'.format(ori), 'MeasuresCamera.xml'))
     img_meas = micmac.parse_im_meas(os.path.join('Ori-{}'.format(ori), 'MeasuresIm-{}.xml'.format(fn_img)))
@@ -46,9 +49,16 @@ def resample_hex(fn_img, scale, ori='InterneScan'):
     ds.FlushCache()
     ds = None
 
-    out_ds = gdal.Warp('tmp_{}'.format(fn_img), fn_img, xRes=1, yRes=1,
-                       outputBounds=[0, 0, all_meas.j_cam.max(), all_meas.i_cam.max()],
-                       resampleAlg=gdal.GRA_NearestNeighbour)
+    options = {'xRes': 1, 'yRes': 1,
+               'outputBounds': [-500, -500, all_meas.j_cam.max() + 500, all_meas.i_cam.max() + 500],
+               'resampleAlg': alg,
+               'tps': tps}
+
+    if order is not None:
+        options['polynomialOrder'] = order
+
+    out_ds = gdal.Warp('tmp_{}'.format(fn_img), fn_img, **options)
+
     meta_shp = '{"shape": ' + '[{}, {}]'.format(out_ds.RasterYSize, out_ds.RasterXSize) + '}'
     out_ds.SetMetadata({'TIFFTAG_IMAGEDESCRIPTION': meta_shp})
     out_ds.FlushCache()

--- a/src/spymicmac/tools/post_process_micmac.py
+++ b/src/spymicmac/tools/post_process_micmac.py
@@ -17,6 +17,8 @@ def _argparser():
     parser.add_argument('--do_ortho', action='store_true',
                         help='Post-process the orthomosaic in Ortho-{dirmec}, as well. Assumes that you have run'
                              'mm3d Tawny with Out=Orthophotomosaic first.')
+    parser.add_argument('--ind_ortho', action='store_true',
+                        help='Post-process the individual orthophotos in  in Ortho-{dirmec}, as well.')
     return parser
 
 

--- a/src/spymicmac/tools/preprocess_kh9.py
+++ b/src/spymicmac/tools/preprocess_kh9.py
@@ -230,7 +230,6 @@ def main():
         for fn_img in imlist:
             shutil.move(fn_img + '.tif', 'Orig')
 
-
     if do['balance']:
         print('Using CLAHE to balance image contrast')
         for fn_img in imlist:
@@ -261,4 +260,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/spymicmac/tools/register_relative.py
+++ b/src/spymicmac/tools/register_relative.py
@@ -42,6 +42,11 @@ def _argparser():
                               'If fn_ortho is set, uses that file instead.')
     _parser.add_argument('-max_iter', action='store', type=int, default=5,
                          help='the maximum number of Campari iterations to run [5]')
+    _parser.add_argument('-use_cps', action='store_true',
+                         help='split the GCPs into GCPs and CPs, to quantify the uncertainty of the '
+                              'camera model [False]')
+    _parser.add_argument('-cp_frac', type=float, default=0.2,
+                         help='the fraction of GCPs to use when splitting into GCPs and CPs [0.2]')
     return _parser
 
 
@@ -64,7 +69,9 @@ def main():
                       density=args.density,
                       allfree=args.no_allfree,
                       useortho=args.useortho,
-                      max_iter=args.max_iter)
+                      max_iter=args.max_iter,
+                      use_cps=args.use_cps,
+                      cp_frac=args.cp_frac)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR incorporates a number of fixes and updates, especially to the KH-9 MC pre-processing stages. This includes using a thin plate spline transformation to resample the raw images to the réseau grid, and fixing a bug that caused small ~1 px shifts when joining two image halves together.

`spymicmac.image`:
- fix an off-by-one indexing error in `splitter`
- continued improvements to `get_rough_frame`

`spymicmac.matching`:
- increase the threshold for finding peaks in `find_crosses`
- tighten the RANSAC threshold for finding matching keypoints in `match_halves`

`spymicmac.micmac`:
- add support for using checkpoints
- add additional arguments and fix bugs in `malt`
- add support for georeferencing and masking individual ortho images in `post_process`

`spymicmac.register`:
- add support for using checkpoints

`spymicmac.resample`:
- use thin plate spline transformation by default, and add support for changing resampling algorithm in `resample_hex`

`spymicmac.tools`:
- add new arguments to `post_process_micmac`
- add new arguments to `register_relative`