### PR TITLE
add multicam, additional registration options

### DIFF
--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -165,7 +165,7 @@ def _filter_fid_matches(coords_all, measures_cam):
         these_meas = coords_all.loc[c].set_index('gcp').join(measures_cam)
 
         model, inliers = ransac((these_meas[['im_col', 'im_row']].values, these_meas[['j', 'i']].values),
-                                SimilarityTransform, min_samples=nfids-1, residual_threshold=10, max_trials=20)
+                                SimilarityTransform, min_samples=3, residual_threshold=10, max_trials=20)
         try:
             resids.append(model.residuals(these_meas[['im_col', 'im_row']].values,
                                           these_meas[['j', 'i']].values).mean())

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -1479,15 +1479,21 @@ def _dense_skimage(split_img, oy, ox, return_des, detector_kwargs):
     descriptors = []
 
     for ind, img in enumerate(split_img):
-        orb.detect_and_extract(img)
-        kp, des = orb.keypoints, orb.descriptors
+        try:
+            orb.detect_and_extract(img)
+            kp, des = orb.keypoints, orb.descriptors
 
-        descriptors.append(des)
+            descriptors.append(des)
 
-        kp[:, 1] += ox[ind]
-        kp[:, 0] += oy[ind]
+            kp[:, 1] += ox[ind]
+            kp[:, 0] += oy[ind]
 
-        keypoints.append(kp)
+            keypoints.append(kp)
+        except RuntimeError as e:
+            if "ORB found no features." in e.args[0]:
+                continue
+            else:
+                raise e
 
     keypoints = np.concatenate(keypoints, axis=0)
     descriptors = np.concatenate(descriptors, axis=0)

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -259,21 +259,23 @@ def _get_residuals(meas_img, meas_cam):
         raise RuntimeError("Unable to estimate an affine transformation")
 
 
-def _rotate_meas(meas, angle):
+def _rotate_meas(meas, angle, pp=None):
     M = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
 
     rot = meas.copy()
 
-    mean_j = meas.j.mean()
-    mean_i = meas.i.mean()
+    if pp is not None:
+        shift_j, shift_i = pp.x, pp.y
+    else:
+        shift_j, shift_i = meas.j.mean(), meas.i.mean()
 
-    rot.j -= mean_j
-    rot.i -= mean_i
+    rot.j -= shift_j
+    rot.i -= shift_i
 
     rot[['j', 'i']] = rot[['j', 'i']].values.dot(M)
 
-    rot.j += mean_j
-    rot.i += mean_i
+    rot.j += shift_j
+    rot.i += shift_j
 
     return rot
 

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -1512,7 +1512,7 @@ def _dense_opencv(split_img, oy, ox, split_msk, return_des, detector_kwargs):
 
         for p in kp:
             p.pt = p.pt[0] + ox[ind], p.pt[1] + oy[ind]
-            keypoints.append(kp)
+            keypoints.append(p)
 
     if return_des:
         return keypoints, np.array(descriptors)

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -395,13 +395,14 @@ def inscribed_cross(size, cross_size, width=3, angle=45):
     return circle - padded
 
 
-def templates_from_meas(fn_img, half_size=100):
+def templates_from_meas(fn_img, half_size=100, threshold=False):
     """
     Create fiducial templates from points in a MeasuresIm file.
 
     :param str fn_img: the filename of the image to use. Points for templates will be taken from
         Ori-InterneScan-Measuresim{fn-img}.xml.
     :param int half_size: the half-size of the template to create, in pixels (default: 100)
+    :param bool threshold: return binary templates based on otsu thresholding (default: False)
     :return: **templates** (*dict*) -- a *dict* of (name, template) pairs for each fiducial marker.
     """
     dir_img = os.path.dirname(fn_img)
@@ -418,6 +419,9 @@ def templates_from_meas(fn_img, half_size=100):
     templates = []
     for ind, row in meas_im.iterrows():
         subimg, _, _ = make_template(img, (row.i, row.j), half_size=half_size)
+        if threshold:
+            subimg = (subimg > filters.threshold_otsu(subimg)).astype(np.uint8)
+
         templates.append(subimg)
 
     return dict(zip(meas_im.name.values, templates))

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1939,6 +1939,12 @@ def post_process(projstr, out_name, dirmec, do_ortho=True, ind_ortho=False):
     shutil.copy(os.path.join(dirmec, f'Z_Num{level}_DeZoom{zoomf}_STD-MALT.tfw'),
                 os.path.join(dirmec, f'AutoMask_STD-MALT_Num_{level-1}.tfw'))
 
+    if os.path.exists(os.path.join(dirmec, f"Correl_STD-MALT_Num_{level-1}_Tile_0_0.tif")):
+        mosaic_micmac_tiles(f"Correl_STD-MALT_Num_{level-1}", dirmec)
+
+    if os.path.exists(os.path.join(dirmec, f"Z_Num{level}_DeZoom{zoomf}_STD-MALT_Tile_0_0.tif")):
+        mosaic_micmac_tiles(f"Z_Num{level}_DeZoom{zoomf}_STD-MALT", dirmec)
+
     subprocess.Popen(['gdal_translate', '-a_nodata', '0', '-a_srs', projstr,
                       os.path.join(dirmec, f'Correl_STD-MALT_Num_{level-1}.tif'),
                       'tmp_corr.tif']).wait()
@@ -1970,6 +1976,9 @@ def post_process(projstr, out_name, dirmec, do_ortho=True, ind_ortho=False):
     if do_ortho:
         ortho = os.path.join('Ortho-' + dirmec, 'Orthophotomosaic.tif')
 
+        if os.path.join('Ortho-' + dirmec, 'Orthophotomosaic_Tile_0_0.tif'):
+            mosaic_micmac_tiles('Orthophotomosaic', 'Ortho-' + dirmec)
+
         subprocess.Popen(['gdal_translate', '-a_nodata', '0', '-a_srs', projstr, ortho, 'tmp_ortho.tif']).wait()
 
         # TODO: re-size the mask to fit the ortho image, if needed
@@ -1983,6 +1992,10 @@ def post_process(projstr, out_name, dirmec, do_ortho=True, ind_ortho=False):
     if ind_ortho:
         imlist = sorted(glob('OIS*.tif'))
         for fn_img in imlist:
+
+            if os.path.join('Ortho-' + dirmec, f"Ort_{os.path.splitext(fn_img)[0]}_Tile_0_0.tif"):
+                mosaic_micmac_tiles(f"Ort_{os.path.splitext(fn_img)[0]}", 'Ortho-' + dirmec)
+
             _mask_ortho(fn_img, out_name, dirmec, projstr)
 
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1075,7 +1075,7 @@ def find_connected_blocks(pattern='OIS*.tif', dir_homol='Homol'):
     :return: blocks -- a list containing lists of connected blocks of images
     """
     imlist = glob(pattern)
-    homols = [_get_homol(fn_img, dir_homol) for fn_img in imlist]
+    homols = [[fn for fn in _get_homol(fn_img, dir_homol) if fn in imlist] for fn_img in imlist]
 
     hdict = dict(zip(imlist, homols))
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1123,6 +1123,24 @@ def tapioca(img_pattern='OIS.*tif', res_low=400, res_high=1200):
     return p.wait()
 
 
+def martini(img_pattern='OIS.*tif'):
+    """
+    Run mm3d Martini, which provides a quick way to orient images without solving for camera parameters.
+
+    :param str img_pattern: The image pattern to pass to Martini (default: OIS.*tif)
+    """
+    if os.name == 'nt':
+        echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
+    else:
+        echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
+
+    args = ['mm3d', 'Martini', img_pattern]
+
+    p = subprocess.Popen(args, stdin=echo.stdout)
+
+    return p.wait()
+
+
 def tapas(cam_model, ori_out, img_pattern='OIS.*tif', in_cal=None, lib_foc=True, lib_pp=True, lib_cd=True):
     """
     Run mm3d Tapas with a given camera calibration model.

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1105,20 +1105,21 @@ def find_connected_blocks(pattern='OIS*.tif', dir_homol='Homol'):
     return blocks
 
 
-def separate_blocks(pattern='OIS*.tif', dir_homol='Homol'):
+def separate_blocks(pattern='OIS*.tif', dir_homol='Homol', min_size=2):
     """
     Based on homologous points, find connected blocks of images and then separate the files into sub-folders.
     Moves files from {dir_homol} and Pastis, along with the image files.
 
-    :param str pattern: the search pattern to use to get image names
-    :param str dir_homol: the Homologue directory to use to determine what images are connected
+    :param str pattern: the search pattern to use to get image names (default: OIS*.tif)
+    :param str dir_homol: the Homologue directory to use to determine what images are connected (default: Homol)
+    :param int min_size: the minimum number of images to be considered a block (default: 2)
     """
     # get connected blocks
     blocks = find_connected_blocks(pattern, dir_homol)
 
     # find single unconnected images
-    singles = sorted([im for imgs in blocks for im in imgs if len(imgs) == 1])
-    blocks = [b for b in blocks if len(b) > 1]
+    singles = sorted([im for imgs in blocks for im in imgs if len(imgs) < min_size])
+    blocks = [b for b in blocks if len(b) >= min_size]
 
     # make directory
     os.makedirs('singles', exist_ok=True)

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1269,12 +1269,13 @@ def tapioca(img_pattern='OIS.*tif', res_low=400, res_high=1200, fn_neighbours=No
     return p.wait()
 
 
-def martini(img_pattern='OIS.*tif', in_ori=None):
+def martini(img_pattern='OIS.*tif', in_ori=None, ori_out=None):
     """
     Run mm3d Martini, which provides a quick way to orient images without solving for camera parameters.
 
     :param str img_pattern: The image pattern to pass to Martini (default: OIS.*tif)
     :param str in_ori: the orientation directory to use to initialize the calibration (default: None)
+    :param str ori_out: the name of the output orientation directory (default: Martini)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -1285,6 +1286,9 @@ def martini(img_pattern='OIS.*tif', in_ori=None):
 
     if in_ori is not None:
         args.append(f"InOri={in_ori}")
+
+    if ori_out is not None:
+        args.append(f"OriOut={ori_out}")
 
     p = subprocess.Popen(args, stdin=echo.stdout)
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -338,7 +338,7 @@ def create_measurescamera_xml(fn_csv, ori='InterneScan', translate=False, name='
                xml_declaration=True, encoding="utf-8")
 
 
-def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, how='mean'):
+def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, how='mean', write_xml=True):
     """
     Use a set of located fiducial markers to create a MeasuresCamera file using the average location of each fiducial
     marker.
@@ -348,6 +348,7 @@ def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, 
     :param str ori: The Ori- directory containing the MeasuresIm files (default: InterneScan)
     :param float scan_res: the scanning resolution of the images in m (default: 2.5e-5; 25 µm)
     :param str how: what average to use for the output locations. Must be one of [mean, median].
+    :param bool write_xml: write the MeasuresCamera.xml file in addition to a CSV (default: True)
     """
     assert how in ['mean', 'median'], "how must be one of [mean, median]"
 
@@ -414,7 +415,9 @@ def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, 
 
     all_meas.to_csv('AllMeasures.csv', index=False)
     avg_meas.to_csv('AverageMeasures.csv')
-    create_measurescamera_xml('AverageMeasures.csv', ori=ori, translate=False, name='name', x='j', y='i')
+
+    if write_xml:
+        create_measurescamera_xml('AverageMeasures.csv', ori=ori, translate=False, name='name', x='j', y='i')
 
 
 def _meas_center(meas, pairs):

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -17,6 +17,7 @@ import difflib
 import xml.etree.ElementTree as ET
 from glob import glob
 from shapely.strtree import STRtree
+from shapely.geometry import LineString
 from skimage.io import imread, imsave
 from skimage.transform import AffineTransform, SimilarityTransform
 from skimage.measure import ransac
@@ -336,14 +337,14 @@ def create_measurescamera_xml(fn_csv, ori='InterneScan', translate=False, name='
                xml_declaration=True, encoding="utf-8")
 
 
-def estimate_measures_camera(approx_meas, ori='InterneScan', scan_res=2.5e-5, how='mean'):
+def estimate_measures_camera(pairs, ori='InterneScan', scan_res=2.5e-5, how='mean'):
     """
     Use a set of located fiducial markers to create a MeasuresCamera file using the average location of each fiducial
     marker.
 
-    :param DataFrame approx_meas: A DataFrame with the (very approximate) locations of the fiducial markers.
+    :param pairs: a list of pairs of co-linear fiducial markers
     :param str ori: The Ori- directory containing the MeasuresIm files (default: InterneScan)
-    :param float scan_res: the scanning resolution of the images in microns
+    :param float scan_res: the scanning resolution of the images in m (default: 2.5e-5; 25 µm)
     :param str how: what average to use for the output locations. Must be one of [mean, median].
     """
     assert how in ['mean', 'median'], "how must be one of [mean, median]"
@@ -351,19 +352,24 @@ def estimate_measures_camera(approx_meas, ori='InterneScan', scan_res=2.5e-5, ho
     meas_list = sorted(glob('MeasuresIm*.xml', root_dir=f'Ori-{ori}'))
 
     all_meas = []
+
     for fn_meas in meas_list:
-        meas = parse_im_meas(os.path.join(f'Ori-{ori}', fn_meas))
-        joined = meas.set_index('name').join(approx_meas.set_index('name'), lsuffix='_img', rsuffix='_cam')
+        meas = parse_im_meas(os.path.join(f'Ori-{ori}', fn_meas)).set_index('name')
+        ppx, ppy = _meas_center(meas, pairs)
+        meas['j'] -= ppx
+        meas['i'] -= ppy
 
-        model, inliers = ransac((joined[['j_img', 'i_img']].values, joined[['j_cam', 'i_cam']].values),
-                                SimilarityTransform, min_samples=len(meas) - 1, residual_threshold=2,
-                                max_trials=5000)
+        collinear = [LineString(meas.loc[p, ['j', 'i']].values) for p in pairs]
 
-        rot = matching._rotate_meas(meas, -model.rotation)
-        meas['j'] = rot['j'] - model.translation[0]
-        meas['i'] = rot['i'] - model.translation[1]
+        meas.loc[pairs[0], ['collim_dist']] = collinear[0].length
+        meas.loc[pairs[1], ['collim_dist']] = collinear[1].length
 
-        all_meas.append(meas)
+        scale = np.mean([c.length for c in collinear])
+
+        meas['j'] = meas['j'] / scale
+        meas['i'] = meas['i'] / scale
+
+        all_meas.append(meas.reset_index())
 
     all_meas = pd.concat(all_meas, ignore_index=True)
 
@@ -372,11 +378,23 @@ def estimate_measures_camera(approx_meas, ori='InterneScan', scan_res=2.5e-5, ho
     else:
         avg_meas = all_meas.groupby('name').median(numeric_only=True)
 
-    avg_meas['j'] *= scan_res * 1000  # convert from microns to mm
-    avg_meas['i'] *= scan_res * 1000  # convert from microns to mm
+    avg_meas['j'] -= avg_meas['j'].min()
+    avg_meas['i'] -= avg_meas['i'].min()
 
-    avg_meas.reset_index(names='name').to_file('AverageMeasures.csv')
+    scale = avg_meas['collim_dist'].mean()
+
+    avg_meas['j'] *= scale * scan_res * 1000  # convert from m to mm
+    avg_meas['i'] *= scale * scan_res * 1000  # convert from m to mm
+
+    avg_meas.to_csv('AverageMeasures.csv')
     create_measurescamera_xml('AverageMeasures.csv', ori=ori, translate=False, name='name', x='j', y='i')
+
+
+def _meas_center(meas, pairs):
+    # TODO: generalize this based on multiple collinear pairs
+    collims = [LineString(meas.loc[p, ['j', 'i']].values) for p in pairs]
+    pp = collims[0].intersection(collims[1])
+    return pp.x, pp.y
 
 
 def generate_multicam_csv(patterns=None, prefix='OIS-Reech_', fn_out='camera_defs.csv',

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -379,8 +379,9 @@ def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, 
 
         meas['resid'] = model.residuals(joined[['j_img', 'i_img']].values, joined[['j_cam', 'i_cam']].values)
 
-        noscale = AffineTransform(translation=model.translation, rotation=model.rotation)
+        noscale = AffineTransform(translation=model.translation, rotation=model.rotation, shear=model.shear)
         rot = noscale(meas[['j', 'i']].values)
+        # rot = model(meas[['j', 'i']].values)
 
         meas['j'] = rot[:, 0]
         meas['i'] = rot[:, 1]

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1041,7 +1041,7 @@ def _generate_glob(fn_ids):
     tree.write('Tmp-SL-Glob.xml', pretty_print=True, xml_declaration=True, encoding="utf-8")
 
 
-def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True):
+def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True, gamma=None):
     """
     Run SaisieAppuisInit to locate the fiducial markers for a given list of images.
 
@@ -1049,6 +1049,7 @@ def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True):
     :param str flavor: which version of SaisieAppuisInit to run. Must be one of [qt, og] (default: qt)
     :param str fn_cam: the filename for the MeasuresCamera.xml file (default: Ori-InterneScan/MeasuresCamera.xml)
     :param bool clean: remove any image files in Tmp-SaisieAppuis
+    :param float gamma: Gamma adjustment value for Saisie (default: 1.0)
     """
     assert flavor in ['qt', 'og'], "flavor must be one of [qt, og]"
 
@@ -1089,7 +1090,12 @@ def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True):
             shutil.copy('Tmp-SL-Glob.xml',
                         os.path.join('Tmp-SaisieAppuis', f'Tmp-SL-Glob-MeasuresIm-{fn_img}.xml'))
 
-        p = subprocess.Popen(['mm3d', saisie, fn_img, 'NONE', 'id_fiducials.txt', f'MeasuresIm-{fn_img}.xml'])
+        saisie_args = ['mm3d', saisie, fn_img, 'NONE', 'id_fiducials.txt', f'MeasuresIm-{fn_img}.xml']
+
+        if gamma is not None:
+            saisie_args.append(f"Gama={gamma}")
+
+        p = subprocess.Popen(saisie_args)
         p.wait()
 
         shutil.move(f'MeasuresIm-{fn_img}-S2D.xml', os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml'))

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -73,11 +73,11 @@ def pairs_from_footprints(imlist, fprints=None, name_field='ID', prefix='OIS-Ree
     Using a list of images and a collection of image footprints, return a list of potential image pairs for processing
     with Tapioca.
 
-    :param list imlist: a list of (original) image names to use (e.g., without 'OIS-Reech\_')
+    :param list imlist: a list of (original) image names to use (e.g., without 'OIS-Reech_')
     :param GeoDataFrame fprints: a vector dataset of footprint polygons. If not provided, will attempt to download
         metadata from USGS for the images.
     :param str name_field: the field in fprints table that contains the image name
-    :param str prefix: the prefix attached to the image name read by Tapioca (default: 'OIS-Reech\_')
+    :param str prefix: the prefix attached to the image name read by Tapioca (default: 'OIS-Reech_')
     :param str file_ext: the file extension for the images read by Tapioca (default: .tif)
     :param str dataset: the USGS dataset name to search if no footprints are provided (default: AERIAL_COMBIN)
     :return: **pairs** (*list*) -- a list of tuples representing image pairs
@@ -829,13 +829,12 @@ def write_image_mesures(imlist, gcps, outdir='.', sub='', ort_dir='Ortho-MEC-Rel
         impts = pd.read_csv('Auto-{}.txt'.format(im), sep=' ', names=['j', 'i'])
         # impts_nodist = pd.read_csv('NoDist-{}.txt'.format(im), sep=' ', names=['j', 'i'])
 
-        # TODO: replace GeoImg.find_valid_bbox
-        # could potentially polygonize the valid mask
-        xmin, ymin, xmax, ymax = img_geo.bounds
+        footprint = (img_geo > 0).polygonize().ds.geometry.values[0]
+        valid_pts = footprint.contains(gpd.points_from_xy(gcps.rel_x, gcps.rel_y))
 
         # valid_pts = get_valid_image_points(img.shape, impts, impts_nodist)
-        valid_pts = np.logical_and.reduce([xmin <= gcps.rel_x, gcps.rel_x < xmax,
-                                           ymin <= gcps.rel_y, gcps.rel_y < ymax])
+        # valid_pts = np.logical_and.reduce([xmin <= gcps.rel_x, gcps.rel_x < xmax,
+        #                                    ymin <= gcps.rel_y, gcps.rel_y < ymax])
 
         if np.count_nonzero(valid_pts) == 0:
             continue
@@ -1602,7 +1601,7 @@ def checkpoints(img_pattern, ori, fn_cp, fn_meas, fn_resids=None, ret_df=True):
     p.wait()
 
     if fn_resids is not None and ret_df:
-        return pd.read_csv(str(fn_resids) + '_RollCtrl.txt', delimiter='\s+', names=['id', 'xres', 'yres', 'zres'])
+        return pd.read_csv(str(fn_resids) + '_RollCtrl.txt', delimiter=r'\s+', names=['id', 'xres', 'yres', 'zres'])
 
 
 def banana(fn_dem, fn_ref, deg=2, dZthresh=200., fn_mask=None, spacing=100):
@@ -2023,21 +2022,21 @@ def get_autogcp_locations(ori, meas_file, imlist):
     :param str meas_file: The Measures file to find image locations for
     :param list imlist: a list of image names
     """
-    nodist = '-'.join([ori, 'NoDist'])
+    # nodist = '-'.join([ori, 'NoDist'])
 
     # copy the orientation directory to a new, "nodist" directory
-    shutil.copytree(ori, nodist, dirs_exist_ok=True)
+    # shutil.copytree(ori, nodist, dirs_exist_ok=True)
 
-    autocals = glob('AutoCal*.xml', root_dir=nodist)
-    for autocal in autocals:
-        _remove_distortion_coeffs(os.path.join(nodist, autocal))
+    # autocals = glob('AutoCal*.xml', root_dir=nodist)
+    # for autocal in autocals:
+    #    _remove_distortion_coeffs(os.path.join(nodist, autocal))
 
     for im in imlist:
-        _update_autocal(nodist, im)
+        # _update_autocal(nodist, im)
 
-        p = subprocess.Popen(['mm3d', 'XYZ2Im', os.path.join(nodist, f'Orientation-{im}.xml'),
-                              meas_file, f'NoDist-{im}.txt'])
-        p.wait()
+        # p = subprocess.Popen(['mm3d', 'XYZ2Im', os.path.join(nodist, f'Orientation-{im}.xml'),
+        #                       meas_file, f'NoDist-{im}.txt'])
+        # p.wait()
 
         p = subprocess.Popen(['mm3d', 'XYZ2Im', os.path.join(ori, f'Orientation-{im}.xml'),
                               meas_file, f'Auto-{im}.txt'])

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1161,19 +1161,29 @@ def tapas(cam_model, ori_out, img_pattern='OIS.*tif', in_cal=None, lib_foc=True,
     return p.wait()
 
 
-def apericloud(ori, img_pattern='OIS.*tif'):
+def apericloud(ori, img_pattern='OIS.*tif', fn_out=None, with_points=True):
     """
     Run mm3d AperiCloud to create a point cloud layer
 
     :param str ori: the input orientation to use
     :param str img_pattern: the image pattern to pass to AperiCloud (default: OIS.*tif)
+    :param str fn_out: the output filename (default: AperiCloud_{ori}.ply)
+    :param bool with_points: display the point cloud (default: True)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
     else:
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
 
-    p = subprocess.Popen(['mm3d', 'AperiCloud', img_pattern, ori], stdin=echo.stdout)
+    args = ['mm3d', 'AperiCloud', img_pattern, ori]
+
+    if fn_out is not None:
+        args.append(f"Out={fn_out}")
+
+    if not with_points:
+        args.append(f"WithPoints=0")
+
+    p = subprocess.Popen(args, stdin=echo.stdout)
 
     return p.wait()
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1044,7 +1044,11 @@ def _get_homol(fn_img, dir_homol='Homol'):
     if not os.path.exists(os.path.join(dir_homol, 'Pastis' + fn_img)):
         return []
     else:
-        return sorted([h.split('.dat')[0] for h in glob('*.dat', root_dir=os.path.join(dir_homol, 'Pastis' + fn_img))])
+        sees = sorted([h.split('.dat')[0] for h in glob('*.dat', root_dir=os.path.join(dir_homol, 'Pastis' + fn_img))])
+        seen = sorted([os.path.split(fn)[0].replace('Pastis', '') for fn in
+                       glob(f"**/{fn_img}.dat", recursive=True, root_dir='Homol')])
+
+        return list(set(sees + seen))
 
 
 # adapted from the fantastic answer provided by
@@ -1053,10 +1057,11 @@ def _get_homol(fn_img, dir_homol='Homol'):
 def _get_connected_block(img, seen, hdict):
     result = []
     imgs = set([img])
+
     while imgs:
         img = imgs.pop()
         seen.add(img)
-        imgs = imgs or set(hdict[img]) - seen
+        imgs.update(set(hdict[img]) - seen)
         result.append(img)
 
     return result, seen

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1269,11 +1269,12 @@ def tapioca(img_pattern='OIS.*tif', res_low=400, res_high=1200, fn_neighbours=No
     return p.wait()
 
 
-def martini(img_pattern='OIS.*tif'):
+def martini(img_pattern='OIS.*tif', in_ori=None):
     """
     Run mm3d Martini, which provides a quick way to orient images without solving for camera parameters.
 
     :param str img_pattern: The image pattern to pass to Martini (default: OIS.*tif)
+    :param str in_ori: the orientation directory to use to initialize the calibration (default: None)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -1281,6 +1282,9 @@ def martini(img_pattern='OIS.*tif'):
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
 
     args = ['mm3d', 'Martini', img_pattern]
+
+    if in_ori is not None:
+        args.append(f"InOri={in_ori}")
 
     p = subprocess.Popen(args, stdin=echo.stdout)
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1287,7 +1287,8 @@ def martini(img_pattern='OIS.*tif'):
     return p.wait()
 
 
-def tapas(cam_model, ori_out, img_pattern='OIS.*tif', in_cal=None, lib_foc=True, lib_pp=True, lib_cd=True):
+def tapas(cam_model, ori_out=None, img_pattern='OIS.*tif', in_cal=None, in_ori=None,
+          lib_foc=True, lib_pp=True, lib_cd=True):
     """
     Run mm3d Tapas with a given camera calibration model.
 
@@ -1304,6 +1305,7 @@ def tapas(cam_model, ori_out, img_pattern='OIS.*tif', in_cal=None, lib_foc=True,
     :param str ori_out: the output orientation. Will create a directory, Ori-{ori_out}, with camera parameter files.
     :param str img_pattern: the image pattern to pass to Tapas (default: OIS.*tif)
     :param str in_cal: an input calibration model to refine (default: None)
+    :param str in_ori: a set of orientations to initialize the calibration (default: None)
     :param bool lib_foc: allow the focal length to be calibrated (default: True)
     :param bool lib_pp: allow the principal point to be calibrated (default: True)
     :param bool lib_cd: allow the center of distortion to be calibrated (default: True)
@@ -1313,14 +1315,20 @@ def tapas(cam_model, ori_out, img_pattern='OIS.*tif', in_cal=None, lib_foc=True,
     else:
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
 
+    args = ['mm3d', 'Tapas', cam_model, img_pattern,
+            'LibFoc={}'.format(int(lib_foc)), 'LibPP={}'.format(int(lib_pp)),
+            'LibCD={}'.format(int(lib_cd))]
+
+    if ori_out is not None:
+        args.append('Out=' + ori_out)
+
     if in_cal is not None:
-        p = subprocess.Popen(['mm3d', 'Tapas', cam_model, img_pattern, 'InCal=' + in_cal,
-                              'LibFoc={}'.format(int(lib_foc)), 'LibPP={}'.format(int(lib_pp)),
-                              'LibCD={}'.format(int(lib_cd)), 'Out=' + ori_out], stdin=echo.stdout)
-    else:
-        p = subprocess.Popen(['mm3d', 'Tapas', cam_model, img_pattern,
-                              'LibFoc={}'.format(int(lib_foc)), 'LibPP={}'.format(int(lib_pp)),
-                              'LibCD={}'.format(int(lib_cd)), 'Out=' + ori_out], stdin=echo.stdout)
+        args.append('InCal=' + in_cal)
+
+    if in_ori is not None:
+        args.append('InOri=' + in_ori)
+
+    p = subprocess.Popen(args, stdin=echo.stdout)
 
     return p.wait()
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -829,7 +829,7 @@ def write_image_mesures(imlist, gcps, outdir='.', sub='', ort_dir='Ortho-MEC-Rel
         impts = pd.read_csv('Auto-{}.txt'.format(im), sep=' ', names=['j', 'i'])
         # impts_nodist = pd.read_csv('NoDist-{}.txt'.format(im), sep=' ', names=['j', 'i'])
 
-        footprint = (img_geo > 0).polygonize().ds.geometry.values[0]
+        footprint = (img_geo > 0).polygonize().ds.union_all()
         valid_pts = footprint.contains(gpd.points_from_xy(gcps.rel_x, gcps.rel_y))
 
         # valid_pts = get_valid_image_points(img.shape, impts, impts_nodist)

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1044,11 +1044,7 @@ def _get_homol(fn_img, dir_homol='Homol'):
     if not os.path.exists(os.path.join(dir_homol, 'Pastis' + fn_img)):
         return []
     else:
-        sees = sorted([h.split('.dat')[0] for h in glob('*.dat', root_dir=os.path.join(dir_homol, 'Pastis' + fn_img))])
-        seen = sorted([os.path.split(fn)[0].replace('Pastis', '') for fn in
-                       glob(f"**/{fn_img}.dat", recursive=True, root_dir='Homol')])
-
-        return list(set(sees + seen))
+        return sorted([h.split('.dat')[0] for h in glob('*.dat', root_dir=os.path.join(dir_homol, 'Pastis' + fn_img))])
 
 
 # adapted from the fantastic answer provided by
@@ -1106,8 +1102,8 @@ def separate_blocks(pattern='OIS*.tif', dir_homol='Homol'):
     blocks = find_connected_blocks(pattern, dir_homol)
 
     # find single unconnected images
-    blocks = [b for b in blocks if len(b) > 1]
     singles = sorted([im for imgs in blocks for im in imgs if len(imgs) == 1])
+    blocks = [b for b in blocks if len(b) > 1]
 
     # make directory
     os.makedirs('singles', exist_ok=True)

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -514,7 +514,7 @@ def create_localchantier_xml(name='KH9MC', short_name='KH-9 Hexagon Mapping Came
                 E.Arrite('1 1'),
                 E.Direct(
                     E.PatternTransform(pattern),
-                    E.CalcName(focal)
+                    E.CalcName(f"{focal}")
                 )
             )
         )

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1199,20 +1199,26 @@ def batch_saisie_fids(imlist, flavor='qt', fn_cam=None, clean=True, gamma=None):
     os.remove('Tmp-SL-Glob.xml')
 
 
-def tapioca(img_pattern='OIS.*tif', res_low=400, res_high=1200):
+def tapioca(img_pattern='OIS.*tif', res_low=400, res_high=1200, fn_neighbours=None):
     """
-    Run mm3d Tapioca MulScale
+    Run mm3d Tapioca
 
     :param str img_pattern: The image pattern to pass to Tapioca (default: OIS.*tif)
     :param int res_low: the size of the largest image axis, in pixels, for low-resolution matching (default: 400)
     :param int res_high: the size of the largest image axis, in pixels, for high-resolution matching (default: 1200)
+    :param str fn_neighbours:
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
     else:
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
-    p = subprocess.Popen(['mm3d', 'Tapioca', 'MulScale', img_pattern,
-                          str(res_low), str(res_high)], stdin=echo.stdout)
+
+    if fn_neighbours is None:
+        args = ['mm3d', 'Tapioca', 'MulScale', img_pattern, str(res_low), str(res_high)]
+    else:
+        args = ['mm3d', 'Tapioca', 'File', fn_neighbours, str(res_high)]
+
+    p = subprocess.Popen(args, stdin=echo.stdout)
 
     return p.wait()
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -470,8 +470,8 @@ def estimate_measures_camera(approx, pairs, ori='InterneScan', scan_res=2.5e-5, 
 
         collinear = [LineString(meas.loc[p, ['j', 'i']].values) for p in pairs]
 
-        meas.loc[pairs[0], ['collim_dist']] = collinear[0].length
-        meas.loc[pairs[1], ['collim_dist']] = collinear[1].length
+        for ind, pair in enumerate(pairs):
+            meas.loc[pair, ['collim_dist']] = collinear[ind].length
 
         scale = np.mean([c.length for c in collinear])
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -382,15 +382,19 @@ def estimate_measures_camera(approx_meas, ori='InterneScan', scan_res=2.5e-5, ho
 def generate_multicam_csv(patterns=None, prefix='OIS-Reech_', fn_out='camera_defs.csv',
                           name='', short_name='', film_size='', focal=''):
     """
+    Create a CSV file with camera parameters than can be read by create_localchantier_xml() to use images acquired by
+    multiple cameras.
 
-    :param patterns:
-    :param prefix:
-    :param fn_out:
-    :param name:
-    :param short_name:
-    :param film_size:
-    :param focal:
-    :return:
+    Can be used to create a blank CSV template to be filled out manually, or generated using the optional function
+    arguments.
+
+    :param patterns: a list of filename patterns corresponding to each camera [None]
+    :param str prefix: an optional prefix to add to the matching patterns [OIS-Reech_]
+    :param str fn_out: the name of the CSV file to create [camera_defs.csv]
+    :param name: the name to give each camera. Must be unique.
+    :param short_name: the "short name" description of each camera. Does not need to be unique.
+    :param film_size: the size (width, height in mm) of the frame for each camera. Can be a list of tuples or a str.
+    :param focal: the focal length of each camera, in mm.
     """
     cameras = pd.DataFrame()
 

--- a/src/spymicmac/orientation.py
+++ b/src/spymicmac/orientation.py
@@ -235,7 +235,7 @@ def load_all_orientation(ori, imlist=None):
         df.loc[i, 'altisol'] = altisol
 
     df['geometry'] = points
-    return df
+    return gpd.GeoDataFrame(df)
 
 
 def extend_line(df, first, last):

--- a/src/spymicmac/orientation.py
+++ b/src/spymicmac/orientation.py
@@ -471,12 +471,12 @@ def fix_orientation(cameras, ori_df, ori, nsig=4):
             update_center(name, ori, [new_x, new_y, new_z])
 
 
-def transform_centers(img_gt, ref, imlist, footprints, ori, imgeom=True):
+def transform_centers(rel, ref, imlist, footprints, ori, imgeom=True):
     """
     Use the camera centers in relative space provided by MicMac Orientation files, along with camera centers or
     footprints, to estimate a transformation between the relative coordinate system and the absolute coordinate system.
 
-    :param array-like img_gt: the image GeoTransform (as read from a TFW file)
+    :param Raster rel: the relative image
     :param Raster ref: the reference image to use to determine the output image shape
     :param list imlist: a list of the images that were used for the relative orthophoto
     :param GeoDataFrame footprints: the (approximate) image footprints or camera centers. If geom_type is Polygon, the
@@ -505,7 +505,7 @@ def transform_centers(img_gt, ref, imlist, footprints, ori, imgeom=True):
         footprints.loc[ind, 'name'] = 'OIS-Reech_' + row['ID'] + '.tif'
 
     join = footprints.set_index('name').join(rel_ori.set_index('name'), lsuffix='abs', rsuffix='rel')
-    join.dropna(inplace=True)
+    join.dropna(how='all', inplace=True)
 
     if join.shape[0] > 3:
         width_ratio = _point_spread(rel_ori.geometry)
@@ -530,7 +530,7 @@ def transform_centers(img_gt, ref, imlist, footprints, ori, imgeom=True):
         rel_pts = _get_points([Point(row.xrel, row.yrel) for ii, row in join.iterrows()])
 
     if imgeom:
-        model, inliers = transform_points(ref, ref_pts, img_gt, rel_pts)
+        model, inliers = transform_points(ref, ref_pts, rel, rel_pts)
     else:
         model, inliers = _transform(ref_pts, rel_pts)
 
@@ -538,13 +538,13 @@ def transform_centers(img_gt, ref, imlist, footprints, ori, imgeom=True):
     return model, inliers, join
 
 
-def transform_points(ref, ref_pts, rel_gt, rel_pts):
+def transform_points(ref, ref_pts, rel, rel_pts):
     """
     Given x,y points and two "geo"-referenced images, finds an affine transformation between the two images.
 
     :param Raster ref: the reference image
     :param np.array ref_pts: an Mx2 array of the x,y points in the reference image
-    :param array-like rel_gt: the "geo" transform for the second image, as read from a .tfw file.
+    :param Raster rel: the second image
     :param np.array rel_pts: an Mx2 array of the x,y points in the second image.
     :return:
         - **model** (*AffineTransform*) -- the estimated Affine Transformation between relative and absolute space
@@ -552,10 +552,11 @@ def transform_points(ref, ref_pts, rel_gt, rel_pts):
     """
     ref_ij = np.array(ref.xy2ij(ref_pts[:, 0], ref_pts[:, 1])).T
 
-    rel_ij = np.array([((pt[0] - rel_gt[4]) / rel_gt[0],
-                        (pt[1] - rel_gt[5]) / rel_gt[3]) for pt in rel_pts])
+    rel_ij = np.array(rel.xy2ij(rel_pts[:, 0], rel_pts[:, 1])).T
+    # rel_ij = np.array([((pt[0] - rel_gt[4]) / rel_gt[0],
+    #                     (pt[1] - rel_gt[5]) / rel_gt[3]) for pt in rel_pts])
 
-    model, inliers = _transform(ref_ij[:, ::-1], rel_ij)
+    model, inliers = _transform(ref_ij[:, ::-1], rel_ij[:, ::-1])
 
     return model, inliers
 
@@ -607,10 +608,14 @@ def _get_points(centers):
     norm = _norm_vector(line)  # get the normal vector to the line
 
     pt12 = line.centroid  # get the midpoint of the line
-    # get a point perpendicular to the line at a distance of line.length from the midpoint
-    endpt = Point(pt12.x + line.length * norm[0], pt12.y + line.length * norm[1])
+    # get two points perpendicular to the line, centered on the midpoint
+    endpts = [Point(pt12.x - 0.5 * line.length * norm[0],
+                    pt12.y - 0.5 * line.length * norm[1]),
+              Point(pt12.x + 0.5 * line.length * norm[0],
+                    pt12.y + 0.5 * line.length * norm[1])]
 
-    pts = [(p.x, p.y) for p in [pt1, pt2, pt12, endpt]]
+
+    pts = [(p.x, p.y) for p in [pt1, pt2, pt12] + endpts]
 
     return np.array(pts)
 

--- a/src/spymicmac/register.py
+++ b/src/spymicmac/register.py
@@ -11,12 +11,17 @@ import matplotlib.pyplot as plt
 import geopandas as gpd
 import geoutils as gu
 from glob import glob
+
+import pandas as pd
+from pyogrio.errors import DataSourceError
 from rtree import index
 from shapely.ops import unary_union
 from shapely.geometry.point import Point
 from skimage.io import imread
 from skimage.measure import ransac
 from skimage.transform import AffineTransform, warp
+from tifffile.geodb import Datum
+
 from spymicmac import data, image, matching, micmac, orientation
 
 
@@ -263,7 +268,7 @@ def _get_mask(footprints, img, imlist, landmask=None, glacmask=None):
     fmask.crop(fprint.buffer(img.res[0]*10).bounds, mode='match_pixel', inplace=True)
 
     mask = img.copy(new_array=np.zeros(img.shape))
-    mask[~img.data.mask] = 255
+    mask.data[~img.data.mask] = 255
 
     if landmask is not None:
         lmask = gu.Vector(landmask).create_mask(img)
@@ -291,10 +296,24 @@ def _get_last_malt(dirmec):
     return f'Z_Num{level}_DeZoom{zoomf}_STD-MALT.tif'
 
 
+def _read_gcps(fn_gcp, ref_img):
+    gcps = gpd.read_file(fn_gcp)
+    gcps = gcps.rename(columns={'z': 'elevation', 'name': 'id'})
+
+    if isinstance(gcps, pd.DataFrame):
+        gcps = gpd.GeoDataFrame(gcps, geometry=gpd.points_from_xy(gcps.x, gcps.y, crs=ref_img.crs))
+    else:
+        gcps = gcps.to_crs(ref_img.crs)
+
+    gcps['search_i'], gcps['search_j'] = ref_img.xy2ij(gcps.geometry.x, gcps.geometry.y)
+
+    return gcps
+
+
 def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None, landmask=None, footprints=None,
                       im_subset=None, block_num=None, subscript=None, ori='Relative', ortho_res=8.,
                       imgsource='DECLASSII', density=200, out_dir=None, allfree=True, useortho=False, max_iter=5,
-                      use_cps=False, cp_frac=0.2):
+                      use_cps=False, cp_frac=0.2, fn_gcps=None):
     """
     Register a relative DEM or orthoimage to a reference DEM and/or orthorectified image.
 
@@ -319,6 +338,8 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
     :param int max_iter: the maximum number of Campari iterations to run. (default: 5)
     :param bool use_cps: split the GCPs into GCPs and CPs, to quantify the uncertainty of the camera model (default: False)
     :param float cp_frac: the fraction of GCPs to use when splitting into GCPs and CPs (default: 0.2)
+    :param str fn_gcps: (optional) shapefile or CSV of GCP coordinates to use. Column names should be [(name | id),
+        (z | elevation), x, y]. If CSV is used, x,y should have the same CRS as the reference image.
     """
     print('start.')
 
@@ -388,8 +409,8 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
 
     rough_spacing = max(1000, np.round(max(ref_img.shape) / 20 / 1000) * 1000)
 
-    rough_gcps = matching.find_grid_matches(rough_tfm, ref_img, mask_full.data.data, Minit,
-                                            spacing=int(rough_spacing), dstwin=int(rough_spacing))
+    rough_gcps = matching.find_matches(rough_tfm, ref_img, mask_full.data.data, initM=Minit,
+                                       spacing=int(rough_spacing), dstwin=int(rough_spacing))
 
     try:
         model, inliers = ransac((rough_gcps[['search_j', 'search_i']].values,
@@ -410,14 +431,19 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
     fig.savefig('initial_transformation{}.png'.format(subscript), dpi=200, bbox_inches='tight')
     plt.close(fig)
 
-    # for each of these pairs (src, dst), find the precise subpixel match (or not...)
-    gcps = matching.find_grid_matches(rough_tfm, ref_img, mask_full.data.data, model,
-                                      spacing=density, dstwin=_search_size(rough_tfm.shape))
+    if fn_gcps is not None:
+        gcps = _read_gcps(fn_gcps, ref_img)
+        gcps = matching.find_matches(rough_tfm, ref_img, mask_full.data.data, points=gcps, initM=model,
+                                     spacing=density, dstwin=_search_size(rough_tfm.shape))
+    else:
+        # for each of these pairs (src, dst), find the precise subpixel match (or not...)
+        gcps = matching.find_matches(rough_tfm, ref_img, mask_full.data.data, model,
+                                     spacing=density, dstwin=_search_size(rough_tfm.shape))
 
     x, y = ref_img.ij2xy(gcps['search_i'], gcps['search_j'])
-    gcps['geometry'] = gpd.points_from_xy(x, y, crs=ref_img.crs)
+    gcps = gpd.GeoDataFrame(gcps, geometry=gpd.points_from_xy(x, y, crs=ref_img.crs))
 
-    gcps = gcps.loc[mask_full.data.data[gcps.search_i, gcps.search_j] == 255]
+    gcps = gcps.loc[mask_full.data.data[gcps.search_i.astype(int), gcps.search_j.astype(int)] == 255]
 
     gcps['rel_x'] = reg_gt[4] + gcps['orig_j'].values * reg_gt[0]  # need the original image coordinates
     gcps['rel_y'] = reg_gt[5] + gcps['orig_i'].values * reg_gt[3]
@@ -435,8 +461,8 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
         dem = ref_img
 
     # gcps.crs = {'init': 'epsg:{}'.format(ref_img.epsg)}
-    gcps['elevation'] = dem.interp_points(zip(gcps.geometry.x, gcps.geometry.y))
-    gcps['el_rel'] = rel_dem.interp_points(gcps[['rel_x', 'rel_y']].values)
+    gcps['elevation'] = dem.interp_points((gcps.geometry.x, gcps.geometry.y))
+    gcps['el_rel'] = rel_dem.interp_points((gcps.rel_x, gcps.rel_y))
 
     # drop any gcps where we don't have a DEM value or a valid match
     if dem.nodata is not None:

--- a/src/spymicmac/register.py
+++ b/src/spymicmac/register.py
@@ -386,6 +386,7 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
         fn_reg = os.path.join(dirmec, _get_last_malt(dirmec))
         fn_tfw = fn_reg.replace('.tif', '.tfw')
         reg_img = imread(fn_reg)
+    print(f"Loaded relative image {fn_reg}.")
 
     with open(fn_tfw, 'r') as f:
         reg_gt = [float(l.strip()) for l in f.readlines()]
@@ -418,7 +419,11 @@ def register_relative(dirmec, fn_dem, fn_ref=None, fn_ortho=None, glacmask=None,
         model, inliers = ransac((rough_gcps[['search_j', 'search_i']].values,
                                  rough_gcps[['orig_j', 'orig_i']].values), AffineTransform,
                                 min_samples=6, residual_threshold=20, max_trials=5000)
+        if model is None or np.count_nonzero(inliers) < 6:
+            raise ValueError()
+
         rough_tfm = warp(reg_img, model, output_shape=ref_img.shape, preserve_range=True)
+
     except ValueError as e:
         print('Unable to refine transformation with rough GCPs. Using transform estimated from footprints.')
         model = Minit

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -250,8 +250,8 @@ def _fiducials(fn_img=None, scale=None, fn_cam=None, transform=AffineTransform):
     transform.estimate(joined[['j_img', 'i_img']].values,
                        joined[['j_cam', 'i_cam']].values)
 
-    outshape = ((joined['i_cam'].max() - joined['i_cam'].min()),
-                (joined['j_cam'].max() - joined['j_cam'].min()))
+    outshape = (int(joined['i_cam'].max() - joined['i_cam'].min()),
+                int(joined['j_cam'].max() - joined['j_cam'].min()))
 
     img = io.imread(fn_img)
     img_tfm = warp(img, transform.inverse, output_shape=outshape, preserve_range=True, order=5)

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -6,7 +6,7 @@ import multiprocessing as mp
 import PIL.Image
 from osgeo import gdal
 from skimage import io
-from skimage.transform import SimilarityTransform, warp
+from skimage.transform import AffineTransform, SimilarityTransform, warp
 from scipy import ndimage
 import numpy as np
 from spymicmac import image, micmac, matching
@@ -201,39 +201,40 @@ def align_image_borders(fn_left, fn_right, border):
     mask_right = _border_mask(right, border)
 
 
-def resample_similarity(fn_img, scale, fn_cam=None, nproc=1):
+def resample_fiducials(fn_img, scale, transform=AffineTransform(), fn_cam=None, nproc=1):
     """
-    Resample image(s) using a similarity transform.
+    Resample image(s) using fiducial markers.
 
     :param str|list fn_img: the filename, or a list of filenames, of the image(s)
     :param float scale: the image scale (in mm/pixel) to use
+    :param transform: the type of transformation to use. Should be an instance of skimage.transform (default: AffineTransform)
     :param str fn_cam: the filename for the MeasuresCamera.xml file (default: Ori-InterneScan/MeasuresCamera.xml)
     :param int nproc: the number of processors to use (default: 1)
     :return:
     """
     if type(fn_img) is str:
-        _similarity(fn_img=fn_img, scale=scale, fn_cam=fn_cam)
+        _fiducials(fn_img=fn_img, scale=scale, fn_cam=fn_cam, transform=transform)
     else:
         if nproc > 1:
             pool = mp.Pool(nproc, maxtasksperchild=1)
-            arg_dict = {'scale': scale, 'fn_cam': fn_cam}
+            arg_dict = {'scale': scale, 'fn_cam': fn_cam, 'transform': transform}
             pool_args = [{'fn_img': fn} for fn in fn_img]
             for d in pool_args:
                 d.update(arg_dict)
 
-            pool.map(_similarity_wrapper, pool_args, chunksize=1)
+            pool.map(_fiducials_wrapper, pool_args, chunksize=1)
             pool.close()
             pool.join()
         else:
             for fn in fn_img:
-                _similarity(fn_img=fn, scale=scale, fn_cam=fn_cam)
+                _fiducials(fn_img=fn, scale=scale, fn_cam=fn_cam, transform=transform)
 
 
-def _similarity_wrapper(args):
-    _similarity(**args)
+def _fiducials_wrapper(args):
+    _fiducials(**args)
 
 
-def _similarity(fn_img=None, scale=None, fn_cam=None):
+def _fiducials(fn_img=None, scale=None, fn_cam=None, transform=AffineTransform):
     print(fn_img)
     meas = micmac.parse_im_meas(os.path.join('Ori-InterneScan', f'MeasuresIm-{fn_img}.xml'))
     if fn_cam is None:
@@ -246,14 +247,13 @@ def _similarity(fn_img=None, scale=None, fn_cam=None):
 
     joined = meas.set_index('name').join(measures_cam.set_index('name'), lsuffix='_img', rsuffix='_cam')
 
-    model = SimilarityTransform()
-    model.estimate(joined[['j_img', 'i_img']].values,
-                   joined[['j_cam', 'i_cam']].values)
+    transform.estimate(joined[['j_img', 'i_img']].values,
+                       joined[['j_cam', 'i_cam']].values)
 
     outshape = ((joined['i_cam'].max() - joined['i_cam'].min()),
                 (joined['j_cam'].max() - joined['j_cam'].min()))
 
     img = io.imread(fn_img)
-    img_tfm = warp(img, model.inverse, output_shape=outshape, preserve_range=True, order=5)
+    img_tfm = warp(img, transform.inverse, output_shape=outshape, preserve_range=True, order=5)
 
     io.imsave('OIS-Reech_' + fn_img, img_tfm.astype(np.uint8))

--- a/src/spymicmac/tools/register_relative.py
+++ b/src/spymicmac/tools/register_relative.py
@@ -47,7 +47,10 @@ def _argparser():
                               'camera model [False]')
     _parser.add_argument('-cp_frac', type=float, default=0.2,
                          help='the fraction of GCPs to use when splitting into GCPs and CPs [0.2]')
-    _parser.add_argument('-fn_gcps', action='store', type='str', default=None,
+    _parser.add_argument('-o', '--use_orb', action='store_true',
+                         help='use skimage.feature.ORB to identify GCP locations in the reference image '
+                              '(default: use regular grid for matching)')
+    _parser.add_argument('-fn_gcps', action='store', type=str, default=None,
                          help='(optional) shapefile or CSV of GCP coordinates to use. Column names should be '
                               '[(name | id), (z | elevation), x, y]. If CSV is used, x,y should have the same '
                               'CRS as the reference image.')
@@ -76,6 +79,7 @@ def main():
                       max_iter=args.max_iter,
                       use_cps=args.use_cps,
                       cp_frac=args.cp_frac,
+                      use_orb=args.use_orb,
                       fn_gcps=args.fn_gcps)
 
 

--- a/src/spymicmac/tools/register_relative.py
+++ b/src/spymicmac/tools/register_relative.py
@@ -47,6 +47,10 @@ def _argparser():
                               'camera model [False]')
     _parser.add_argument('-cp_frac', type=float, default=0.2,
                          help='the fraction of GCPs to use when splitting into GCPs and CPs [0.2]')
+    _parser.add_argument('-fn_gcps', action='store', type='str', default=None,
+                         help='(optional) shapefile or CSV of GCP coordinates to use. Column names should be '
+                              '[(name | id), (z | elevation), x, y]. If CSV is used, x,y should have the same '
+                              'CRS as the reference image.')
     return _parser
 
 
@@ -71,7 +75,8 @@ def main():
                       useortho=args.useortho,
                       max_iter=args.max_iter,
                       use_cps=args.use_cps,
-                      cp_frac=args.cp_frac)
+                      cp_frac=args.cp_frac,
+                      fn_gcps=args.fn_gcps)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for processing surveys using images from multiple cameras. It also adds the option of proving GCP coordinates for automatic matching, or identifying potential GCP feature locations using ORB, in addition to the (current) default grid matching.

Additional/specific changes include:

`spymicmac.matching`:
- `find_grid_matches` -> `find_matches`, with option to supply a list of point coordinates rather than using a regular grid.
- add threshold optional argument to `templates_from_meas`

`spymicmac.micmac`:
- `write_neighbour_images` can use either footprint vector file, or matches from a given `Homol` directory.
- added `clean_homol` and `pairs_from_homol`, for removing spurious match files or returning a list of image pairs
- update `estimate_measures_camera` to work with more than two pairs of fiducial markers and scale the results based on the distance between collinear pairs of fiducials.
- add `generate_multicam_csv` to write a csv of camera parameters to be read by `create_localchantier_xml`
- in `write_image_mesures`, identify valid points based on the footprint of the masked ortho image, rather than the bounding box of the ortho image.
- add `separate_blocks`, for moving images into separate folders based on whether they form connected blocks using homologous points
- add wrapper function for calling mm3d Martini
- add additional optional parameters to `tapioca`, `tapas`, `apericloud`
- `post_process_micmac` now checks whether images need to be tiled, and does so

`spymicmac.orientation`:
- add `write_orientation` for writing orientation xml files using a DataFrame of orientation parameters
- `transform_centers` and `transform_points` now use `geoutils.Raster` rather than a transform read from a .tfw file, for consistency with how conversion between image and real-world coordinates is done using `Raster.ij2xy`, `Raster.xy2ij`

`spymicmac.register`:
- add two additional keyword arguments to `register_relative` to allow for alternative methods of identifying/locating GCPs, including using ORB on a highpass filter version of the reference image, or passing a file with GCP coordinates.

`spymicmac.resample`:
- move individual fiducial resampling functions (e.g., `resample_similarity`) into a single function, `resample_fiducials`, that takes a `skimage.transform` transform argument to use for resampling. Additional changes include loading the image(s) to be registered using `geoutils.Raster` to enable the use of `Raster.ij2xy` and `Raster.xy2ij`, which improves the alignment of the final DEM by removing a half-pixel shift. 

`spymicmac.tools.register_relative`:
- add additional arguments based on updates to `spymicmac.register.register_relative`
