### PR TITLE
update/improve tools for processing panoramic cameras with ASP

### DIFF
--- a/src/spymicmac/__init__.py
+++ b/src/spymicmac/__init__.py
@@ -2,10 +2,12 @@
 spymicmac is a python package to help in the processing of historical aerial imagery using MicMac
 """
 from importlib.metadata import version
+from . import asp
 from . import data
+from . import declass
 from . import image
-from . import micmac
 from . import matching
+from . import micmac
 from . import orientation
 from . import register
 from . import resample
@@ -17,6 +19,7 @@ __version__ = version(__name__)
 __all__ = [
     'asp',
     'data',
+    'declass',
     'image',
     'matching',
     'micmac',

--- a/src/spymicmac/asp.py
+++ b/src/spymicmac/asp.py
@@ -17,12 +17,6 @@ sample_params = {
     'KH9': {'f': 1.5, 'tilt': np.deg2rad(10), 'scan_time': 0.7, 'speed': 8000}
 }
 
-usgs_datasets = {
-    'KH4': 'corona2',
-    'KH9': 'declassiii'
-}
-
-
 def _isaft(fn_img):
     return os.path.splitext(fn_img)[0][-4] == 'A'
 
@@ -157,7 +151,7 @@ def cam_from_footprint(fn_img, flavor, scan_res, fn_dem, north_up=True, footprin
 
     # now, get the image footprint, and use ul_corner to get the ul, ur, lr, ll coordinates
     if footprints is None:
-        footprints = data.get_usgs_footprints([clean_name], dataset=usgs_datasets[flavor])
+        footprints = data.get_usgs_footprints([clean_name], dataset=declass.usgs_datasets[flavor])
         fprint = footprints.loc[0, 'geometry']
     else:
         fprint = footprints.loc[footprints['ID'] == clean_name, 'geometry'].values[0]

--- a/src/spymicmac/declass.py
+++ b/src/spymicmac/declass.py
@@ -1,0 +1,51 @@
+import os
+import numpy as np
+
+
+# default initial parameters for panoramic cameras
+sample_params = {
+    'KH4': {'f': 0.61, 'tilt': np.deg2rad(15), 'scan_time': 0.36, 'speed': 7700},
+    'KH9': {'f': 1.5, 'tilt': np.deg2rad(10), 'scan_time': 0.7, 'speed': 8000}
+}
+
+
+# dataset names for searching from USGS EarthExplorer API
+usgs_datasets = {
+    'KH4': 'corona2',
+    'KH9': 'declassiii'
+}
+
+
+def _mission(fn_img):
+    """
+    Extract the mission number from a USGS declassified dataset filename.
+    """
+    if 'OIS-Reech_' in fn_img:
+        fn_img = fn_img.split('OIS-Reech_')[-1]
+    fn_img = os.path.splitext(fn_img)[0]
+
+    return int(fn_img.split('-')[0][-4:])
+
+
+def _mission_to_camera(num):
+    """
+    Given a mission number extracted from a USGS declassified dataset filename, return the camera type associated
+    with that number.
+
+    """
+    if num in range(9031, 9063):
+        return 'KH4'
+    elif num in range(1001, 1053):
+        return 'KH4A'
+    elif num in range(1101, 1118):
+        return 'KH4B'
+    elif num > 1200:
+        return 'KH9'
+
+
+def get_declass_camera(fn_img):
+    """
+
+    """
+    mission = _mission(fn_img)
+    return _mission_to_camera(mission)

--- a/src/spymicmac/matching.py
+++ b/src/spymicmac/matching.py
@@ -1360,7 +1360,9 @@ def do_match(dest_img, ref_img, mask, pt, srcwin, dstwin):
     _i, _j = pt
     submask, _, _ = make_template(mask, pt, srcwin)
 
-    if np.count_nonzero(submask) / submask.size < 0.05:
+    if submask.size == 0:
+        return (np.nan, np.nan), np.nan, np.nan
+    elif np.count_nonzero(submask) / submask.size < 0.05:
         return (np.nan, np.nan), np.nan, np.nan
 
     try:

--- a/src/spymicmac/resample.py
+++ b/src/spymicmac/resample.py
@@ -7,6 +7,7 @@ import PIL.Image
 from osgeo import gdal
 from skimage import io
 from skimage.transform import SimilarityTransform, warp
+from skimage.morphology import disk
 from scipy import ndimage
 import numpy as np
 from spymicmac import image, micmac, matching
@@ -107,7 +108,7 @@ def crop_panoramic(fn_img, flavor, marker_size=31, fact=None, return_vals=False)
 
     img = io.imread(fn_img)
     if flavor == 'KH4':
-        rails = matching.find_rail_marks(img)
+        rails = matching.find_rail_marks(img, marker=disk(marker_size))
         rotated, angle = rotate_from_rails(img, rails)
 
         # crop the lower part of the image to avoid introducing a bright line at the bottom

--- a/src/spymicmac/tools/preprocess_kh9.py
+++ b/src/spymicmac/tools/preprocess_kh9.py
@@ -95,34 +95,40 @@ def _argparser():
     parser.add_argument('--skip', action='store', type=str, nargs='+', default='none',
                         help='The pre-processing steps to skip.')
     parser.add_argument('--tar_ext', action='store', type=str, default='.tgz',
-                        help='Extension for tar files (default: .tgz)')
+                        help='Extension for tar files [.tgz]')
     parser.add_argument('-s', '--scale', action='store', type=int, default=70,
-                        help='The scale of the resampled images, in pixels per mm. (default: 70)')
+                        help='The scale of the resampled images, in pixels per mm. [70]')
     parser.add_argument('--clip_limit', action='store', type=float, default=0.005,
-                        help='Clipping limit, for contrast-limited adaptive histogram equalization. (default: 0.005)')
+                        help='Clipping limit, for contrast-limited adaptive histogram equalization. [0.005]')
+    parser.add_argument('-r', '--reversed', action='store_true',
+                        help='Order of image parts is reversed (a is the right side of the image). [False]')
+    parser.add_argument('-o', '--overlap', action='store', type=int, default=2000,
+                        help='The amount of overlap between image parts to use to search for matches. [2000]')
+    parser.add_argument('-k', '--block_size', action='store', type=int, default=2000,
+                    help='the number of rows each search sub-block should cover [2000].')
     parser.add_argument('-b', '--blend', action='store_true',
-                        help='Blend across image halves to prevent a sharp line at edge.')
+                        help='Blend across image halves to prevent a sharp line at edge. [False]')
     parser.add_argument('--add_sfs', action='store_true',
                         help='use SFS to help find tie points in low-contrast images [False]')
     parser.add_argument('--res_low', action='store', type=int, default=400,
                         help='the size of the largest image axis, in pixels, '
-                             'for low-resolution matching with Tapioca (default: 400)')
+                             'for low-resolution matching with Tapioca [400]')
     parser.add_argument('--res_high', action='store', type=int, default=1200,
                         help='the size of the largest image axis, in pixels, '
-                             'for low-resolution matching with Tapioca (default: 1200)')
+                             'for low-resolution matching with Tapioca [1200]')
     parser.add_argument('--camera_model', action='store', type=str, default='RadialExtended',
-                        help='The camera calibration model to use for Tapas (default: RadialExtended)')
+                        help='The camera calibration model to use for Tapas [RadialExtended]')
     parser.add_argument('--ori', action='store', type=str, default='Relative',
-                        help='The output Ori directory to create using Tapas (default: Relative)')
+                        help='The output Ori directory to create using Tapas [Relative]')
     parser.add_argument('--init_cal', action='store', type=str, default='Init',
-                        help='The initial calibration Ori to use for Tapas (default: Init)')
+                        help='The initial calibration Ori to use for Tapas [Init]')
     parser.add_argument('--lib_foc', action='store_true',
-                        help='Use LibFoc=1 for mm3d Tapas (default: LibFoc=0)')
+                        help='Use LibFoc=1 for mm3d Tapas [LibFoc=0]')
     parser.add_argument('--lib_pp', action='store_true',
-                        help='Use LibPP=1 for mm3d Tapas (default: LibPP=0)')
+                        help='Use LibPP=1 for mm3d Tapas [LibPP=0]')
     parser.add_argument('--lib_cd', action='store_true',
-                        help='Use LibCD=1 for mm3d Tapas (default: LibCD=0)')
-    parser.add_argument('-n', '--nproc', type=int, default=1, help='number of sub-processes to use (default: 1).')
+                        help='Use LibCD=1 for mm3d Tapas [LibCD=0]')
+    parser.add_argument('-n', '--nproc', type=int, default=1, help='number of sub-processes to use [1].')
     return parser
 
 
@@ -182,7 +188,13 @@ def main():
         else:
             for fn_img in half_list:
                 print(fn_img)
-                join_hexagon(fn_img, blend=args.blend)
+
+                join_args = {'overlap': args.overlap,
+                             'block_size': args.block_size,
+                             'blend': args.blend,
+                             'is_reversed': args.reversed}
+
+                join_hexagon(fn_img, **join_args)
                 shutil.move(fn_img + '_a.tif', 'halves')
                 shutil.move(fn_img + '_b.tif', 'halves')
 


### PR DESCRIPTION
This PR makes some improvements to the ASP processing tools and fixes a few errors in other parts of the code. The biggest change is adding an additional sub-package, `spymicmac.declass`, which can be used to handle image metadata.

`spymicmac.asp`:
- change default IMC parameter value based on camera type identified from file name, based on values estimated by Ghuffar et al. (2022)
- using image footprint and DEM, optionally calculate image mean elevation to write to camera file using `optical_bar_cam`
- improve performance of identifying which corner coordinate corresponds to which footprint coordinate.

`spymicmac.declass`:
- add tools for identifying mission number and panoramic camera type based on file name
- identify USGS data type using camera type / flavor

`spymicmac.resample`:
- add `marker` keyword argument to `crop_panoramic` to fix error when calling `spymicmac.matching.find_rail_marks`

`spymicmac.tools`:
- add additional command line arguments to `preprocess_kh9` to pass to `spymicmac.image.join_hexagon`