### PR TITLE
add tools for plotting distortion

### DIFF
--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -843,7 +843,7 @@ def write_cam_xml(fn_xml: Union[str, Path], cam_dict: dict, fraser: bool = True)
             E.KnownConv('eConvApero_DistM2C'),
                 E.PP(_format_tup(cam_dict['pp'])),
                 E.F(f"{cam_dict['focal']}"),
-                E.SzIm(_format_tup(cam_dict['size'])),
+                E.SzIm(_format_tup([int(pp) for pp in cam_dict['size']])),
                 dist_model
         )
     )

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1459,7 +1459,7 @@ def martini(img_pattern: str = 'OIS.*tif', in_ori: Union[None, str] = None, ori_
 
 def tapas(cam_model: str, ori_out: Union[str, None] = None, img_pattern: str = 'OIS.*tif',
           in_cal: Union[str, None] = None, in_ori: Union[str, None] = None, lib_foc: bool = True,
-          lib_pp: bool = True, lib_cd: bool = True) -> int:
+          lib_pp: bool = True, lib_cd: bool = True, dir_homol: Union[str, None] = None) -> int:
     """
     Run mm3d Tapas with a given camera calibration model.
 
@@ -1480,6 +1480,7 @@ def tapas(cam_model: str, ori_out: Union[str, None] = None, img_pattern: str = '
     :param lib_foc: allow the focal length to be calibrated
     :param lib_pp: allow the principal point to be calibrated
     :param lib_cd: allow the center of distortion to be calibrated
+    :param dir_homol: the name of the Homol directory to use (default: Homol)
     """
     if os.name == 'nt':
         echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
@@ -1498,6 +1499,9 @@ def tapas(cam_model: str, ori_out: Union[str, None] = None, img_pattern: str = '
 
     if in_ori is not None:
         args.append('InOri=' + in_ori)
+
+    if dir_homol is not None:
+        args.append('SH=' + dir_homol)
 
     p = subprocess.Popen(args, stdin=echo.stdout)
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -1367,7 +1367,7 @@ def batch_saisie_fids(imlist: list, flavor: str = 'qt', fn_cam: Union[None, str]
 
 
 def tapioca(img_pattern: str = 'OIS.*tif', res_low: int = 400, res_high: int = 1200,
-            fn_neighbours: Union[str, Path, None] = None) -> None:
+            fn_neighbours: Union[str, Path, None] = None) -> int:
     """
     Run mm3d Tapioca to find image tie points.
 
@@ -1391,8 +1391,44 @@ def tapioca(img_pattern: str = 'OIS.*tif', res_low: int = 400, res_high: int = 1
     return p.wait()
 
 
+def schnaps(img_pattern: str = 'OIS.*tif',
+            nb_win: Union[None, int] = None,
+            min_pct_coverage: Union[None, float, int] = None,
+            move_bad: bool = False) -> int:
+    """
+    Run mm3d Schnaps, which removes dubious tie points in image geometry. Helps improve
+        performance of Tapas and Martini steps.
+
+    :param img_pattern: The image pattern to pass to Schnaps (default: OIS.*tif)
+    :param nb_win: the minimum number of points to accept in each image; only used if also
+        moving "bad" images (default: 1000)
+    :param min_pct_coverage: the minimum percent coverage to use to accept an image; only used if also
+        moving "bad" images (default: 30)
+    :param move_bad: move bad images to a folder called "Poubelle"
+    """
+    if os.name == 'nt':
+        echo = subprocess.Popen('echo', stdout=subprocess.PIPE, shell=True)
+    else:
+        echo = subprocess.Popen('echo', stdout=subprocess.PIPE)
+
+    args = ['mm3d', 'Schnaps', img_pattern]
+
+    if nb_win is not None:
+        args.append(f"NbWin={nb_win}")
+
+    if min_pct_coverage is not None:
+        args.append(f"minPercentCoverage={min_pct_coverage}")
+
+    if move_bad:
+        args.append(f"MoveBadImgs={int(move_bad)}")
+
+    p = subprocess.Popen(args, stdin=echo.stdout)
+
+    return p.wait()
+
+
 def martini(img_pattern: str = 'OIS.*tif', in_ori: Union[None, str] = None, ori_out: Union[None, str] = None,
-            quick: bool = True) -> None:
+            quick: bool = True) -> int:
     """
     Run mm3d Martini, which provides a quick way to orient images without solving for camera parameters.
 
@@ -1423,7 +1459,7 @@ def martini(img_pattern: str = 'OIS.*tif', in_ori: Union[None, str] = None, ori_
 
 def tapas(cam_model: str, ori_out: Union[str, None] = None, img_pattern: str = 'OIS.*tif',
           in_cal: Union[str, None] = None, in_ori: Union[str, None] = None, lib_foc: bool = True,
-          lib_pp: bool = True, lib_cd: bool = True) -> None:
+          lib_pp: bool = True, lib_cd: bool = True) -> int:
     """
     Run mm3d Tapas with a given camera calibration model.
 
@@ -1469,7 +1505,7 @@ def tapas(cam_model: str, ori_out: Union[str, None] = None, img_pattern: str = '
 
 
 def apericloud(ori: str, img_pattern: str = 'OIS.*tif',
-               fn_out: Union[str, None] = None, with_points: bool = True) -> None:
+               fn_out: Union[str, None] = None, with_points: bool = True) -> int:
     """
     Run mm3d AperiCloud to create a point cloud layer
 
@@ -1500,7 +1536,7 @@ def malt(imlist: Union[str, list], ori: str, zoomf: int = 1, zoomi: Union[None, 
          dirmec: str = 'MEC-Malt', seed_img: Union[str, Path, None] = None, seed_xml: Union[str, Path, None] = None,
          resol_terr: Union[float, int, None] = None, resol_ort: Union[float, int, None] = None,
          cost_trans: Union[float, int, None] = None, szw: Union[int, None] = None,
-         regul: Union[float, None] = None, do_ortho: bool = True, do_mec: bool = True) -> None:
+         regul: Union[float, None] = None, do_ortho: bool = True, do_mec: bool = True) -> int:
     """
     Run mm3d Malt Ortho.
 
@@ -1568,7 +1604,7 @@ def malt(imlist: Union[str, list], ori: str, zoomf: int = 1, zoomi: Union[None, 
     return p.wait()
 
 
-def tawny(dirmec: str, radiomegal: bool = False) -> None:
+def tawny(dirmec: str, radiomegal: bool = False) -> int:
     """
     Run mm3d Tawny to create an orthomosaic.
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -781,7 +781,7 @@ def load_cam_xml(fn_cam: Union[str, Path]) -> dict:
         for ind, coef in enumerate(rad_part.findall('CoeffDist')):
             cam_dict[f"K{ind+1}"] = float(coef.text)
 
-        for param in ['P1', 'P2', 'b1', 'b2']:
+        for param in ['P1', 'P2']: #, 'b1', 'b2']:
             if dist_model.find(param) is not None:
                 cam_dict[param] = float(dist_model.find(param).text)
             else:
@@ -810,7 +810,7 @@ def write_cam_xml(fn_xml: Union[str, Path], cam_dict: dict, fraser: bool = True)
     rad_coefs = [p for p in cam_dict.keys() if 'K' in p]
 
     if fraser:
-        for param in ['P1', 'P2', 'b1', 'b2']:
+        for param in ['P1', 'P2']:
             if param not in cam_dict.keys():
                 cam_dict[param] = '0.0'
 
@@ -824,8 +824,8 @@ def write_cam_xml(fn_xml: Union[str, Path], cam_dict: dict, fraser: bool = True)
                 rad_part,
                 E.P1(f"{cam_dict['P1']}"),
                 E.P2(f"{cam_dict['P2']}"),
-                E.b1(f"{cam_dict['b1']}"),
-                E.b2(f"{cam_dict['b2']}"),
+                #E.b1(f"{cam_dict['b1']}"),
+                #E.b2(f"{cam_dict['b2']}"),
             )
         )
 

--- a/src/spymicmac/micmac.py
+++ b/src/spymicmac/micmac.py
@@ -781,7 +781,7 @@ def load_cam_xml(fn_cam: Union[str, Path]) -> dict:
         for ind, coef in enumerate(rad_part.findall('CoeffDist')):
             cam_dict[f"K{ind+1}"] = float(coef.text)
 
-        for param in ['P1', 'P2']: #, 'b1', 'b2']:
+        for param in ['P1', 'P2', 'b1', 'b2']:
             if dist_model.find(param) is not None:
                 cam_dict[param] = float(dist_model.find(param).text)
             else:
@@ -824,8 +824,8 @@ def write_cam_xml(fn_xml: Union[str, Path], cam_dict: dict, fraser: bool = True)
                 rad_part,
                 E.P1(f"{cam_dict['P1']}"),
                 E.P2(f"{cam_dict['P2']}"),
-                #E.b1(f"{cam_dict['b1']}"),
-                #E.b2(f"{cam_dict['b2']}"),
+                E.b1(f"{cam_dict['b1']}"),
+                E.b2(f"{cam_dict['b2']}"),
             )
         )
 

--- a/src/spymicmac/orientation.py
+++ b/src/spymicmac/orientation.py
@@ -671,22 +671,17 @@ def scale_intrinsics(fn_cam: Union[str, Path], scale: float) -> dict:
     cam_dict['cdist'] = np.array([float(p) for p in cam_dict['cdist'].split(' ')]) * scale
     cam_dict['size'] = np.array([float(p) for p in cam_dict['size'].split(' ')]) * scale
 
-    for ii in range(1, 4):
-        cam_dict[f"K{ii}"] = float(cam_dict[f"K{ii}"]) * scale
-
-    if 'K4' in cam_dict:
-        cam_dict['K4'] = float(cam_dict['K4']) * scale
-
-    if 'K5' in cam_dict:
-        cam_dict['K5'] = float(cam_dict['K5']) * scale
+    order = len([kk for kk in cam_dict.keys() if 'K' in kk])
+    for ii in range(1, order + 1):
+        cam_dict[f"K{ii}"] = float(cam_dict[f"K{ii}"]) / scale ** (2*ii)
 
     for pp in ['P1', 'P2']:
         if pp in cam_dict:
-            cam_dict[pp] = float(cam_dict[pp]) * scale
+            cam_dict[pp] = float(cam_dict[pp]) / scale ** 2
 
     for pp in ['b1', 'b2']:
         if pp in cam_dict:
-            cam_dict[pp] = float(cam_dict[pp]) * scale
+            cam_dict[pp] = float(cam_dict[pp]) / scale
 
     return cam_dict
 

--- a/src/spymicmac/preprocessing.py
+++ b/src/spymicmac/preprocessing.py
@@ -138,7 +138,8 @@ def batch_resample(imlist: list, args) -> None:
     pool.join()
 
 
-def _handle_steps(proc_steps, steps, skips):
+def _handle_steps(proc_steps, steps, skips, opt_steps=[], option=None):
+
     if type(steps) is str:
         assert steps in set(proc_steps + ['all']), f"steps must be one of {['all'] + proc_steps}"
     else:
@@ -157,7 +158,21 @@ def _handle_steps(proc_steps, steps, skips):
         if type(steps) is not list: steps = [ steps ]
         do_step = [step in steps for step in proc_steps]
 
-    do = dict(zip(proc_steps, do_step))
+    if type(option) is str:
+        assert option in set(opt_steps + ['all', 'none']), f"option must be one of {['all', 'none'] + opt_steps}"
+    else:
+        for opt in option:
+            assert opt in opt_steps, f"{opt} not recognized"
+
+    if option == 'all':
+        do_step += [True] * len(opt_steps)
+    elif option == 'none':
+        do_step += [False] * len(opt_steps)
+    else:
+        if type(option) is not list: option = [ option ]
+        do_step += [step in option for step in opt_steps]
+
+    do = dict(zip(proc_steps + opt_steps, do_step))
 
     if skips != 'none':
         if type(skips) is not list: skips = [ skips ]
@@ -168,7 +183,8 @@ def _handle_steps(proc_steps, steps, skips):
     return do
 
 
-def preprocess_kh9_mc(steps: Union[str, list] = 'all', skip: Union[str, list] = 'none', nproc: Union[int, str] = 1,
+def preprocess_kh9_mc(steps: Union[str, list] = 'all', skip: Union[str, list] = 'none',
+                      option: Union[str, list] = 'none', nproc: Union[int, str] = 1,
                       add_sfs: bool = False, cam_csv: str = 'camera_defs.csv', tar_ext: str = '.tgz',
                       is_reversed: bool = False, overlap: int = 2000, block_size: int = 2000, blend: bool = False,
                       scale: int = 70, clip_limit: float = 0.005, res_low: int = 400, res_high: int = 1200,
@@ -183,21 +199,30 @@ def preprocess_kh9_mc(steps: Union[str, list] = 'all', skip: Union[str, list] = 
     - join: joins scanned image halves
     - reseau: finds reseau marker locations in the joined image
     - erase: erases reseau markers from image
-    - filter: use a 1-sigma gaussian filter to smooth the images before resampling
     - resample: resamples images to common size using the reseau marker locations
-    - balance: use contrast-limited adaptive histogram equalization (clahe) to improve contrast in the image
     - tapioca: calls mm3d Tapioca MulScale to find tie points
-    - schnaps: calls mm3d Schnaps to clean/filter tie points
     - tapas: calls mm3d Tapas to calibrate camera model, find relative image orientation
     - aperi: calls mm3d AperiCloud to create point cloud using calibrated camera model
+
+    Additional optional steps can be included using the 'option' argument:
+
+    - filter: use a 1-sigma gaussian filter to smooth the images before resampling. Done before resampling the images.
+    - balance: use contrast-limited adaptive histogram equalization (clahe) to improve contrast in the image. Done
+        after resampling the images.
+    - schnaps: calls mm3d Schnaps to clean/filter tie points. Done after calling Tapioca and before calling Tapas.
 
     To run steps individually, pass them to the steps argument as a list. For example, to only run the 'reseau' and
     'erase' steps:
 
         preprocess_kh9_mc(steps=['reseau', 'erase'])
 
-    :param steps: The pre-processing steps to run
+    Similarly, to run the 'reseau', 'erase', and 'balance' steps:
+
+        preprocess_kh9_mc(steps=['reseau', 'erase'], option='balance')
+
+    :param steps: The default pre-processing steps to run
     :param skip: The pre-processing steps to skip
+    :param option: The optional pre-processing steps to run
     :param nproc: The number of sub-processes to use - either an integer value, or 'max'. If 'max',
         uses mp.cpu_count() to determine the total number of processors available.
     :param add_sfs: use SFS to help find tie points in low-contrast images
@@ -225,10 +250,10 @@ def preprocess_kh9_mc(steps: Union[str, list] = 'all', skip: Union[str, list] = 
         nproc = mp.cpu_count()
         print(f"Using {nproc} processors for steps that use multiprocessing.")
 
-    proc_steps = ['extract', 'join', 'reseau', 'erase', 'filter', 'resample',
-                  'balance', 'tapioca', 'schnaps', 'tapas', 'aperi']
+    proc_steps = ['extract', 'join', 'reseau', 'erase', 'resample', 'tapioca', 'tapas', 'aperi']
+    opt_steps = ['filter', 'balance', 'schnaps']
 
-    do = _handle_steps(proc_steps, steps, skip)
+    do = _handle_steps(proc_steps, steps, skip, opt_steps=opt_steps, option=option)
 
     # initialize the xml files needed
     initialize_kh9_mc(add_sfs=add_sfs, cam_csv=cam_csv)

--- a/src/spymicmac/register.py
+++ b/src/spymicmac/register.py
@@ -411,9 +411,9 @@ def register_relative(dirmec: str, fn_dem: Union[str, Path], fn_ref: Union[str, 
                       im_subset: Union[str, None] = None, block_num: Union[str, None] = None,
                       subscript: Union[str, None] = None, ori: str ='Relative', ortho_res: Union[float, int] = 8.,
                       imgsource: str = 'DECLASSII', strategy: str = 'grid', density: int = 200,
-                      out_dir: Union[str, Path, None] = None, allfree: bool = True, useortho: bool = False,
-                      max_iter: int = 5, use_cps: bool = False, cp_frac: float = 0.2, use_orb: bool = False,
-                      fn_gcps: Union[str, Path, None] = None) -> None:
+                      out_dir: Union[str, Path, None] = None, allfree: bool = True, dir_homol: str = 'Homol',
+                      useortho: bool = False, max_iter: int = 5, use_cps: bool = False, cp_frac: float = 0.2,
+                      use_orb: bool = False, fn_gcps: Union[str, Path, None] = None) -> None:
     """
     Register a relative DEM or orthoimage to a reference DEM and/or orthorectified image.
 
@@ -437,6 +437,7 @@ def register_relative(dirmec: str, fn_dem: Union[str, Path], fn_ref: Union[str, 
     :param density: pixel spacing to look for GCPs
     :param out_dir: output directory to save auto GCP files to
     :param allfree: run Campari setting all parameters free
+    :param dir_homol: the name of the Homol directory to use for Campari (default: Homol)
     :param useortho: use the orthomosaic in Ortho-{dirmec} rather than the DEM. If fn_ortho is
         set, uses that file instead.
     :param max_iter: the maximum number of Campari iterations to run.
@@ -701,7 +702,7 @@ def register_relative(dirmec: str, fn_dem: Union[str, Path], fn_ref: Union[str, 
 
     # now, iterate campari to refine the orientation
     gcps = micmac.iterate_campari(gcps, out_dir, match_pattern, subscript, ref_img.res[0], ortho_res,
-                                  rel_ori=ori, allfree=allfree, max_iter=max_iter)
+                                  rel_ori=ori, allfree=allfree, max_iter=max_iter, homol=dir_homol)
 
     if use_cps:
         cp_resids = micmac.checkpoints(match_pattern, f"Ori-TerrainFinal{subscript}",

--- a/src/spymicmac/tools/preprocess_kh9_mc.py
+++ b/src/spymicmac/tools/preprocess_kh9_mc.py
@@ -20,18 +20,31 @@ def _argparser():
     - tapas: calls mm3d Tapas to calibrate camera model, find relative image orientation
     - aperi: calls mm3d AperiCloud to create point cloud using calibrated camera model
 
+    Additional optional steps can be included using the 'option' argument:
+
+    - filter: use a 1-sigma gaussian filter to smooth the images before resampling. Done before resampling the images.
+    - balance: use contrast-limited adaptive histogram equalization (clahe) to improve contrast in the image. Done
+        after resampling the images.
+    - schnaps: calls mm3d Schnaps to clean/filter tie points. Done after calling Tapioca and before calling Tapas.
+
     To run steps individually, use the --steps flag with the corresponding step name(s). For example, to only run the
     'reseau' and 'erase' steps:
     
-    preprocess_kh9 --steps reseau erase <additional arguments>
+        preprocess_kh9_mc --steps reseau erase <additional arguments>
+
+    Similarly, to run the 'reseau', 'erase', and 'balance' steps:
+    
+        preprocess_kh9_mc --steps reseau erase --option balance <additional arguments>
 
     """
     parser = argparse.ArgumentParser(description=helpstr,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--steps', action='store', type=str, nargs='+', default='all',
-                        help='The pre-processing steps to run (default: all).')
+                        help='The default pre-processing steps to run (default: all).')
     parser.add_argument('--skip', action='store', type=str, nargs='+', default='none',
                         help='The pre-processing steps to skip (default: none).')
+    parser.add_argument('--option', action='store', type=str, nargs='+', default='none',
+                        help='The optional pre-processing steps to skip (default: none).')
     parser.add_argument('-n', '--nproc', type=str, default=1,
                         help='The number of sub-processes to use - either an integer value, or max. '
                              'If max, uses mp.cpu_count() to determine the total number of processors '

--- a/src/spymicmac/tools/preprocess_kh9_mc.py
+++ b/src/spymicmac/tools/preprocess_kh9_mc.py
@@ -16,6 +16,7 @@ def _argparser():
     - resample: resamples images to common size using the reseau marker locations
     - balance: use contrast-limited adaptive histogram equalization (clahe) to improve contrast in the image
     - tapioca: calls mm3d Tapioca MulScale to find tie points
+    - schnaps: calls mm3d Schnaps to clean/filter tie points    
     - tapas: calls mm3d Tapas to calibrate camera model, find relative image orientation
     - aperi: calls mm3d AperiCloud to create point cloud using calibrated camera model
 

--- a/src/spymicmac/tools/register_relative.py
+++ b/src/spymicmac/tools/register_relative.py
@@ -39,6 +39,8 @@ def _argparser():
                          help="strategy for generating GCPs. Must be one of: grid, random, or chebyshev. "
                               "Note that if 'random' is used, density is the approximate number of points, "
                               "rather than the distance between grid points (default: grid).")
+    _parser.add_argument('--dir_homol', action='store', type=str, default='Homol',
+                         help="the name of the Homol directory to use for Campari")
     _parser.add_argument('-density', action='store', type=int, default=200,
                          help='pixel spacing to look for GCPs (default: 200)')
     _parser.add_argument('-no_allfree', action='store_true',


### PR DESCRIPTION
This PR merges the following changes:

`spymicmac.micmac`:
- `.load_cam_xml()` now loads numeric values, rather than str
- adds `.schnaps()` for interfacing with mm3d Schnaps for tie point filtering
- adds `dir_homol` argument to `.tapas()`

`spymicmac.orientation`:
- adds `.scale_intrinsics()`, `.radial_distortion()`, `.standard_distortion()`, and `.plot_lens_distortion()` for plotting and visualizing camera distortion

`spymicmac.preprocessing`:
- adds `option` argument to `.preprocess_kh9_mc()` to allow for optional pre-processing steps like balancing
- adds `schnaps` as an optional step

`spymicmac.register`:
- adds `dir_homol` as an argument to `.register_relative()`, for passing to `micmac.iterate_campari()`

`spymicmac.tools`:
- updates arguments, text for `preprocess_kh9_mc`
- updates arguments, text for `register_relative`
